### PR TITLE
fix KSendCommandReadResponse

### DIFF
--- a/examples/protonect/Protonect.cpp
+++ b/examples/protonect/Protonect.cpp
@@ -211,7 +211,8 @@ int KSendCommandReadResponse(libusb_device_handle *handle, cmd_header& cmd, int 
 
 	//Read expected response complete
 	uint8_t responseData[512];
-	r = KReadCommandResponse(handle, cmd, 512, responseData, transferred);
+	int transferredComplete;
+	r = KReadCommandResponse(handle, cmd, 512, responseData, &transferredComplete);
 
 	if (r == K_RESPONSE_COMPLETE)
 	{


### PR DESCRIPTION
fix KSendCommandReadResponse to return correct number of transferred bytes
