### PR TITLE
libjpeg_turbo fails to configure

### DIFF
--- a/depends/install_mac.sh
+++ b/depends/install_mac.sh
@@ -19,7 +19,7 @@ cd $LIBJPEG_SOURCE_DIR
 # libjpeg-turbo is missing some files config files (config.guess and config.sub)
 cp $LIBUSBX_SOURCE_DIR/config.guess ./
 cp $LIBUSBX_SOURCE_DIR/config.sub ./
-./configure --disable-dependency-tracking --with-jpeg8 --prefix=$LIBJPEG_INSTALL_DIR 
+./configure --disable-dependency-tracking --host x86_64-apple-darwin --with-jpeg8 --prefix=$LIBJPEG_INSTALL_DIR 
 make && make install
 
 cd $DEPENDS_DIR


### PR DESCRIPTION
As pointed out in the build recipe of libjpeg_turbo:
## 64-bit Build on 64-bit OS X

Add

  --host x86_64-apple-darwin NASM=/opt/local/bin/nasm

to the configure command line.  NASM 2.07 or later from MacPorts must be
installed.

configure will fail on 64bit systems without this flag due to:
"configure: error: configuration problem: maybe object file format mismatch". I guess there is hardly any Macs  out there with USB3 but without 64bit OS. NASM should also be installed, in my case its installed from homebrew and found in the PATH.
