### PR TITLE
Added a libfreenect2_api export macro - to apply __declspec(dllexport) i...

### DIFF
--- a/examples/protonect/include/libfreenect2/depth_packet_processor.h
+++ b/examples/protonect/include/libfreenect2/depth_packet_processor.h
@@ -30,6 +30,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <libfreenect2/libfreenect2_export.h>
 #include <libfreenect2/frame_listener.hpp>
 #include <libfreenect2/packet_processor.h>
 
@@ -45,10 +46,10 @@ struct DepthPacket
 
 typedef PacketProcessor<DepthPacket> BaseDepthPacketProcessor;
 
-class DepthPacketProcessor : public BaseDepthPacketProcessor
+class LIBFREENECT2_API DepthPacketProcessor : public BaseDepthPacketProcessor
 {
 public:
-  struct Config
+  struct LIBFREENECT2_API Config
   {
     float MinDepth;
     float MaxDepth;
@@ -109,7 +110,7 @@ protected:
 
 class OpenGLDepthPacketProcessorImpl;
 
-class OpenGLDepthPacketProcessor : public DepthPacketProcessor
+class LIBFREENECT2_API OpenGLDepthPacketProcessor : public DepthPacketProcessor
 {
 public:
   OpenGLDepthPacketProcessor(void *parent_opengl_context_ptr);
@@ -139,7 +140,7 @@ private:
 // use pimpl to hide opencv dependency
 class CpuDepthPacketProcessorImpl;
 
-class CpuDepthPacketProcessor : public DepthPacketProcessor
+class LIBFREENECT2_API CpuDepthPacketProcessor : public DepthPacketProcessor
 {
 public:
   CpuDepthPacketProcessor();

--- a/examples/protonect/include/libfreenect2/frame_listener.hpp
+++ b/examples/protonect/include/libfreenect2/frame_listener.hpp
@@ -28,11 +28,12 @@
 #define FRAME_LISTENER_HPP_
 
 #include <cstddef>
+#include <libfreenect2/libfreenect2_export.h>
 
 namespace libfreenect2
 {
 
-struct Frame
+struct LIBFREENECT2_API Frame
 {
   enum Type
   {
@@ -58,7 +59,7 @@ struct Frame
   }
 };
 
-class FrameListener
+class LIBFREENECT2_API FrameListener
 {
 public:
   virtual ~FrameListener();

--- a/examples/protonect/include/libfreenect2/frame_listener_impl.h
+++ b/examples/protonect/include/libfreenect2/frame_listener_impl.h
@@ -37,7 +37,7 @@ typedef std::map<Frame::Type, Frame*> FrameMap;
 
 class SyncMultiFrameListenerImpl;
 
-class SyncMultiFrameListener : public FrameListener
+class LIBFREENECT2_API SyncMultiFrameListener : public FrameListener
 {
 public:
   SyncMultiFrameListener(unsigned int frame_types);

--- a/examples/protonect/include/libfreenect2/libfreenect2.hpp
+++ b/examples/protonect/include/libfreenect2/libfreenect2.hpp
@@ -27,6 +27,7 @@
 #ifndef LIBFREENECT2_HPP_
 #define LIBFREENECT2_HPP_
 
+#include <libfreenect2/libfreenect2_export.h>
 #include <libfreenect2/frame_listener.hpp>
 
 namespace libfreenect2
@@ -34,7 +35,7 @@ namespace libfreenect2
 
 class PacketPipeline;
 
-class Freenect2Device
+class LIBFREENECT2_API Freenect2Device
 {
 public:
   static const unsigned int VendorId = 0x045E;
@@ -70,7 +71,7 @@ public:
 
 class Freenect2Impl;
 
-class Freenect2
+class LIBFREENECT2_API Freenect2
 {
 public:
   Freenect2(void *usb_context = 0);

--- a/examples/protonect/include/libfreenect2/libfreenect2_export.h
+++ b/examples/protonect/include/libfreenect2/libfreenect2_export.h
@@ -1,0 +1,36 @@
+/*
+* This file is part of the OpenKinect Project. http://www.openkinect.org
+*
+* Copyright (c) 2014 individual OpenKinect contributors. See the CONTRIB file
+* for details.
+*
+* This code is licensed to you under the terms of the Apache License, version
+* 2.0, or, at your option, the terms of the GNU General Public License,
+* version 2.0. See the APACHE20 and GPL2 files for the text of the licenses,
+* or the following URLs:
+* http://www.apache.org/licenses/LICENSE-2.0
+* http://www.gnu.org/licenses/gpl-2.0.txt
+*
+* If you redistribute this file in source form, modified or unmodified, you
+* may:
+*   1) Leave this header intact and distribute it under the same terms,
+*      accompanying it with the APACHE20 and GPL20 files, or
+*   2) Delete the Apache 2.0 clause and accompany it with the GPL2 file, or
+*   3) Delete the GPL v2 clause and accompany it with the APACHE20 file
+* In all cases you must keep the copyright notice intact and include a copy
+* of the CONTRIB file.
+*
+* Binary distributions must follow the binary distribution requirements of
+* either License.
+*/
+
+#ifndef LIBFREENECT2EXPORT_H
+#define LIBFREENECT2EXPORT_H
+
+#ifdef _WIN32
+#  define LIBFREENECT2_API __declspec(dllexport)
+#else
+#  define LIBFREENECT2_API
+#endif
+
+#endif // LIBFREENECT2EXPORT_H

--- a/examples/protonect/include/libfreenect2/opengl.h
+++ b/examples/protonect/include/libfreenect2/opengl.h
@@ -27,13 +27,14 @@
 #ifndef OPENGL_H_
 #define OPENGL_H_
 
+#include <libfreenect2/libfreenect2_export.h>
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
 
 namespace libfreenect2
 {
 
-struct OpenGLContext
+struct LIBFREENECT2_API OpenGLContext
 {
   GLFWwindow *glfw_ctx;
   GLEWContext *glew_ctx;

--- a/examples/protonect/src/tinythread/tinythread.h
+++ b/examples/protonect/src/tinythread/tinythread.h
@@ -143,6 +143,7 @@ freely, subject to the following restrictions:
  #endif
 #endif
 
+#include <libfreenect2/libfreenect2_export.h>
 
 /// Main name space for TinyThread++.
 /// This namespace is more or less equivalent to the @c std namespace for the
@@ -389,7 +390,7 @@ class lock_guard {
 ///   cond.notify_all();
 /// }
 /// @endcode
-class condition_variable {
+class LIBFREENECT2_API condition_variable {
   public:
     /// Constructor.
 #if defined(_TTHREAD_WIN32_)
@@ -478,7 +479,7 @@ class condition_variable {
 
 
 /// Thread class.
-class thread {
+class LIBFREENECT2_API thread {
   public:
 #if defined(_TTHREAD_WIN32_)
     typedef HANDLE native_handle_type;


### PR DESCRIPTION
...nfront of all classes that is used from the library libfreenect2.

If they are not specified VS won't generate a .lib file and protonect will give linking errors.