### PR TITLE
Add timestamps to Frame data.

### DIFF
--- a/examples/protonect/include/libfreenect2/depth_packet_processor.h
+++ b/examples/protonect/include/libfreenect2/depth_packet_processor.h
@@ -40,6 +40,7 @@ namespace libfreenect2
 struct LIBFREENECT2_API DepthPacket
 {
   uint32_t sequence;
+  uint32_t timestamp;
   unsigned char *buffer;
   size_t buffer_length;
 };

--- a/examples/protonect/include/libfreenect2/frame_listener.hpp
+++ b/examples/protonect/include/libfreenect2/frame_listener.hpp
@@ -28,6 +28,7 @@
 #define FRAME_LISTENER_HPP_
 
 #include <cstddef>
+#include <stdint.h>
 #include <libfreenect2/config.h>
 
 namespace libfreenect2
@@ -42,6 +43,7 @@ struct LIBFREENECT2_API Frame
     Depth = 4
   };
 
+  uint32_t timestamp;
   size_t width, height, bytes_per_pixel;
   unsigned char* data;
 

--- a/examples/protonect/include/libfreenect2/rgb_packet_processor.h
+++ b/examples/protonect/include/libfreenect2/rgb_packet_processor.h
@@ -40,7 +40,7 @@ namespace libfreenect2
 struct LIBFREENECT2_API RgbPacket
 {
   uint32_t sequence;
-
+  uint32_t timestamp;
   unsigned char *jpeg_buffer;
   size_t jpeg_buffer_length;
 };

--- a/examples/protonect/src/cpu_depth_packet_processor.cpp
+++ b/examples/protonect/src/cpu_depth_packet_processor.cpp
@@ -742,6 +742,9 @@ void CpuDepthPacketProcessor::process(const DepthPacket &packet)
   if(listener_ == 0) return;
 
   impl_->startTiming();
+  
+  impl_->ir_frame->timestamp = packet.timestamp;
+  impl_->depth_frame->timestamp = packet.timestamp;  
 
   cv::Mat m = cv::Mat::zeros(424, 512, CV_32FC(9)), m_filtered = cv::Mat::zeros(424, 512, CV_32FC(9)), m_max_edge_test = cv::Mat::ones(424, 512, CV_8UC1);
 

--- a/examples/protonect/src/depth_packet_stream_parser.cpp
+++ b/examples/protonect/src/depth_packet_stream_parser.cpp
@@ -111,6 +111,7 @@ void DepthPacketStreamParser::onDataReceived(unsigned char* buffer, size_t in_le
 
               DepthPacket packet;
               packet.sequence = current_sequence_;
+              packet.timestamp = footer->timestamp;
               packet.buffer = buffer_.back().data;
               packet.buffer_length = buffer_.back().length;
 

--- a/examples/protonect/src/opengl_depth_packet_processor.cpp
+++ b/examples/protonect/src/opengl_depth_packet_processor.cpp
@@ -940,6 +940,9 @@ void OpenGLDepthPacketProcessor::process(const DepthPacket &packet)
 
   if(has_listener)
   {
+    ir->timestamp = packet.timestamp;
+    depth->timestamp = packet.timestamp;
+    
     if(!this->listener_->onNewFrame(Frame::Ir, ir))
     {
       delete ir;

--- a/examples/protonect/src/rgb_packet_stream_parser.cpp
+++ b/examples/protonect/src/rgb_packet_stream_parser.cpp
@@ -77,6 +77,10 @@ void RgbPacketStreamParser::onDataReceived(unsigned char* buffer, size_t length)
     // TODO: better method, is unknown0 a magic? detect JPEG magic?
     if(length < 0x4000 && fb.length > sizeof(RgbPacket))
     {
+    
+      // Extract timestamp
+      uint32_t timestamp = *((uint32_t*) &buffer[length - 36]);
+    
       // can the processor handle the next image?
       if(processor_->ready())
       {
@@ -86,6 +90,7 @@ void RgbPacketStreamParser::onDataReceived(unsigned char* buffer, size_t length)
         RawRgbPacket *raw_packet = reinterpret_cast<RawRgbPacket *>(bb.data);
         RgbPacket rgb_packet;
         rgb_packet.sequence = raw_packet->sequence;
+        rgb_packet.timestamp = timestamp;
         rgb_packet.jpeg_buffer = raw_packet->jpeg_buffer;
         rgb_packet.jpeg_buffer_length = bb.length - sizeof(RawRgbPacket);
 

--- a/examples/protonect/src/turbo_jpeg_rgb_packet_processor.cpp
+++ b/examples/protonect/src/turbo_jpeg_rgb_packet_processor.cpp
@@ -112,6 +112,8 @@ void TurboJpegRgbPacketProcessor::process(const RgbPacket &packet)
   {
     impl_->startTiming();
 
+    impl_->frame->timestamp = packet.timestamp;
+    
     int r = tjDecompress2(impl_->decompressor, packet.jpeg_buffer, packet.jpeg_buffer_length, impl_->frame->data, 1920, 1920 * tjPixelSize[TJPF_BGR], 1080, TJPF_BGR, 0);
 
     if(r == 0)


### PR DESCRIPTION
Timestamps for the color data is extracted from a footer that
begins after the JPEG End-Of-Image (0xFF 0xD9)  marker.
The timestamp for the frame is located  36 bytes from the end of the data.