### PR TITLE
A go at making the depth_packet_stream_parser better.

### DIFF
--- a/examples/protonect/include/libfreenect2/depth_packet_processor.h
+++ b/examples/protonect/include/libfreenect2/depth_packet_processor.h
@@ -40,6 +40,7 @@ namespace libfreenect2
 struct LIBFREENECT2_API DepthPacket
 {
   uint32_t sequence;
+  uint32_t timestamp;
   unsigned char *buffer;
   size_t buffer_length;
 };

--- a/examples/protonect/include/libfreenect2/depth_packet_stream_parser.h
+++ b/examples/protonect/include/libfreenect2/depth_packet_stream_parser.h
@@ -64,10 +64,8 @@ private:
   libfreenect2::BaseDepthPacketProcessor *processor_;
 
   libfreenect2::DoubleBuffer buffer_;
-  libfreenect2::Buffer work_buffer_;
 
-  uint32_t current_sequence_;
-  uint32_t current_subsequence_;
+  uint32_t next_subsequence_;
 };
 
 } /* namespace libfreenect2 */

--- a/examples/protonect/include/libfreenect2/frame_listener.hpp
+++ b/examples/protonect/include/libfreenect2/frame_listener.hpp
@@ -28,6 +28,7 @@
 #define FRAME_LISTENER_HPP_
 
 #include <cstddef>
+#include <stdint.h>
 #include <libfreenect2/config.h>
 
 namespace libfreenect2
@@ -42,6 +43,7 @@ struct LIBFREENECT2_API Frame
     Depth = 4
   };
 
+  uint32_t timestamp;
   size_t width, height, bytes_per_pixel;
   unsigned char* data;
 

--- a/examples/protonect/src/cpu_depth_packet_processor.cpp
+++ b/examples/protonect/src/cpu_depth_packet_processor.cpp
@@ -743,6 +743,9 @@ void CpuDepthPacketProcessor::process(const DepthPacket &packet)
 
   impl_->startTiming();
 
+  impl_->ir_frame->timestamp = packet.timestamp;
+  impl_->depth_frame->timestamp = packet.timestamp;
+
   cv::Mat m = cv::Mat::zeros(424, 512, CV_32FC(9)), m_filtered = cv::Mat::zeros(424, 512, CV_32FC(9)), m_max_edge_test = cv::Mat::ones(424, 512, CV_8UC1);
 
   float *m_ptr = m.ptr<float>();

--- a/examples/protonect/src/opengl_depth_packet_processor.cpp
+++ b/examples/protonect/src/opengl_depth_packet_processor.cpp
@@ -935,6 +935,12 @@ void OpenGLDepthPacketProcessor::process(const DepthPacket &packet)
   impl_->run(has_listener ? &ir : 0, has_listener ? &depth : 0);
 
   if(impl_->do_debug) glfwSwapBuffers(impl_->opengl_context_ptr);
+  if (ir != 0)
+    ir->timestamp = packet.timestamp;
+  if (depth != 0)
+    depth->timestamp = packet.timestamp;
+
+
 
   impl_->stopTiming();
 


### PR DESCRIPTION
Iterates through all bytes to find footer but copy data in chunks.
Doesn't use additional working buffer.

I tried to find out why I was getting a lot of errors as shown here https://github.com/OpenKinect/libfreenect2/pull/72#issuecomment-59805519 .

And I found out that its probably not about the code, but rather a hardware/software issue of my dell Precision m6600, with a Renesas USB 3.0 controller not being able to process and acquire all the data that the Kinectv2 sends out.

Also when data is transferred using ISO-mode, the packages are not guaranteed to be received either in order or at all.

I don't have any measures if this is faster/better than the previous, but it avoids using the extra working buffer.

Update: I added a FPS counter(locally) which showed my laptop running about 20(min 16, max 24).  Tried the code on my stationary pc and there are a lot fewer errors and showed about 29-30 fps, hence sometimes a frame is lost. I tried a official depth app also and it runs about 29-30 fps - maybe just a bit more stable at the 30 :)