### PR TITLE
Do not download cl.hpp if it exists

### DIFF
--- a/depends/install_mac.sh
+++ b/depends/install_mac.sh
@@ -23,6 +23,7 @@ cp $LIBUSBX_SOURCE_DIR/config.sub ./
 make && make install
 
 #get the missing cl.hpp from Khronos.org
-cd /System/Library/Frameworks/OpenCL.framework/Versions/A/Headers/ && sudo wget http://www.khronos.org/registry/cl/api/1.2/cl.hpp
+cd /System/Library/Frameworks/OpenCL.framework/Versions/A/Headers/ 
+[ -f cl.hpp ] || sudo wget http://www.khronos.org/registry/cl/api/1.2/cl.hpp
 
 cd $DEPENDS_DIR


### PR DESCRIPTION
This avoids wget create files `cl.hpp.1`, `cl.hpp.2`, etc. when `cl.hpp` already exists.
