### PR TITLE
test_opengl OSX fix

### DIFF
--- a/examples/protonect/src/test_opengl_depth_packet_processor.cpp
+++ b/examples/protonect/src/test_opengl_depth_packet_processor.cpp
@@ -58,6 +58,9 @@ int main(int argc, char **argv) {
   glfwInit();
   glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
   glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+#ifdef __APPLE__
+  glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+#endif
   glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
   glfwWindowHint(GLFW_RESIZABLE, GL_FALSE);


### PR DESCRIPTION
```glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE)``` is required on OSX during glfw setup.