### PR TITLE
fix for wrong define name: WITH_OPENCL_SUPPORT -> LIBFREENECT2_WITH_OPENCL_SUPPORT

### DIFF
--- a/examples/protonect/src/packet_pipeline.cpp
+++ b/examples/protonect/src/packet_pipeline.cpp
@@ -114,7 +114,7 @@ DepthPacketProcessor *OpenGLPacketPipeline::createDepthPacketProcessor()
 }
 
 
-#ifdef WITH_OPENCL_SUPPORT
+#ifdef LIBFREENECT2_WITH_OPENCL_SUPPORT
 
 OpenCLPacketPipeline::OpenCLPacketPipeline(const int deviceId) : deviceId(deviceId)
 { 
@@ -132,6 +132,6 @@ DepthPacketProcessor *OpenCLPacketPipeline::createDepthPacketProcessor()
   
   return depth_processor;
 }
-#endif // WITH_OPENCL_SUPPORT
+#endif // LIBFREENECT2_WITH_OPENCL_SUPPORT
 
 } /* namespace libfreenect2 */


### PR DESCRIPTION
Package pipeline not building correctly because the the define name was not updated.