### PR TITLE
Added timestamp support in Frame(but only Depth and IR)

### DIFF
--- a/examples/protonect/include/libfreenect2/depth_packet_processor.h
+++ b/examples/protonect/include/libfreenect2/depth_packet_processor.h
@@ -40,6 +40,7 @@ namespace libfreenect2
 struct LIBFREENECT2_API DepthPacket
 {
   uint32_t sequence;
+  uint32_t timestamp;
   unsigned char *buffer;
   size_t buffer_length;
 };

--- a/examples/protonect/include/libfreenect2/depth_packet_stream_parser.h
+++ b/examples/protonect/include/libfreenect2/depth_packet_stream_parser.h
@@ -68,6 +68,7 @@ private:
 
   uint32_t current_sequence_;
   uint32_t current_subsequence_;
+  uint32_t current_timestamp_;
 };
 
 } /* namespace libfreenect2 */

--- a/examples/protonect/include/libfreenect2/frame_listener.hpp
+++ b/examples/protonect/include/libfreenect2/frame_listener.hpp
@@ -28,6 +28,7 @@
 #define FRAME_LISTENER_HPP_
 
 #include <cstddef>
+#include <stdint.h>
 #include <libfreenect2/config.h>
 
 namespace libfreenect2
@@ -44,6 +45,9 @@ struct LIBFREENECT2_API Frame
 
   size_t width, height, bytes_per_pixel;
   unsigned char* data;
+  // this is unavailable in rgb Frame
+  //! @note In my environment, this increase about 267 in every frame.so this is not second or milisec.
+  uint32_t timestamp;
 
   Frame(size_t width, size_t height, size_t bytes_per_pixel) :
     width(width),

--- a/examples/protonect/src/cpu_depth_packet_processor.cpp
+++ b/examples/protonect/src/cpu_depth_packet_processor.cpp
@@ -809,6 +809,8 @@ void CpuDepthPacketProcessor::process(const DepthPacket &packet)
       }
   }
 
+  impl_->ir_frame->timestamp = packet.timestamp;
+  impl_->depth_frame->timestamp = packet.timestamp;
   if(listener_->onNewFrame(Frame::Ir, impl_->ir_frame))
   {
     impl_->newIrFrame();

--- a/examples/protonect/src/depth_packet_stream_parser.cpp
+++ b/examples/protonect/src/depth_packet_stream_parser.cpp
@@ -113,7 +113,7 @@ void DepthPacketStreamParser::onDataReceived(unsigned char* buffer, size_t in_le
               packet.sequence = current_sequence_;
               packet.buffer = buffer_.back().data;
               packet.buffer_length = buffer_.back().length;
-
+              packet.timestamp = current_timestamp_;
               processor_->process(packet);
             }
             else
@@ -128,6 +128,7 @@ void DepthPacketStreamParser::onDataReceived(unsigned char* buffer, size_t in_le
 
           current_sequence_ = footer->sequence;
           current_subsequence_ = 0;
+          current_timestamp_ = footer->timestamp;
         }
 
         Buffer &fb = buffer_.front();

--- a/examples/protonect/src/opencl_depth_packet_processor.cpp
+++ b/examples/protonect/src/opencl_depth_packet_processor.cpp
@@ -654,6 +654,9 @@ void OpenCLDepthPacketProcessor::process(const DepthPacket &packet)
 
   impl_->stopTiming();
 
+  impl_->ir_frame->timestamp = packet.timestamp;
+  impl_->depth_frame->timestamp = packet.timestamp;
+
   if(has_listener)
   {
     if(this->listener_->onNewFrame(Frame::Ir, impl_->ir_frame))

--- a/examples/protonect/src/opengl_depth_packet_processor.cpp
+++ b/examples/protonect/src/opengl_depth_packet_processor.cpp
@@ -835,6 +835,9 @@ void OpenGLDepthPacketProcessor::process(const DepthPacket &packet)
 
   impl_->stopTiming();
 
+  ir->timestamp = packet.timestamp;
+  depth->timestamp = packet.timestamp;
+
   if(has_listener)
   {
     if(!this->listener_->onNewFrame(Frame::Ir, ir))


### PR DESCRIPTION
I need timestamp. So I have written patch to get timestamp.But timestamp is unavailable when getting rgb Frame.(never refresh). And this increases 266 or 267 in every frame.So this is not sec or milisec...