### PR TITLE
fixed char comparison warning

### DIFF
--- a/examples/protonect/include/libfreenect2/protocol/response.h
+++ b/examples/protonect/include/libfreenect2/protocol/response.h
@@ -139,7 +139,7 @@ public:
       dump << "   ";
       for (int j = 0; (j < 16) && (j < length); j++)
       {
-        char c = data[i*16+j];
+        unsigned char c = data[i*16+j];
         dump << (((c<32)||(c>128))?'.':c);
       }
       dump << std::endl;


### PR DESCRIPTION
fixes the following warning with clang:
```
examples/protonect/include/libfreenect2/protocol/response.h:143:29: warning: 
      comparison of constant 128 with expression of type 'char' is always false
```
