### PR TITLE
Fix FTBFS on ARM introduced in PR #103

### DIFF
--- a/examples/protonect/include/libfreenect2/depth_packet_processor.h
+++ b/examples/protonect/include/libfreenect2/depth_packet_processor.h
@@ -44,8 +44,6 @@ struct LIBFREENECT2_API DepthPacket
   size_t buffer_length;
 };
 
-// explicit instantiation and export to make vsc++ happy
-template class LIBFREENECT2_API PacketProcessor<DepthPacket>; 
 typedef PacketProcessor<DepthPacket> BaseDepthPacketProcessor;
 
 class LIBFREENECT2_API DepthPacketProcessor : public BaseDepthPacketProcessor

--- a/examples/protonect/include/libfreenect2/rgb_packet_processor.h
+++ b/examples/protonect/include/libfreenect2/rgb_packet_processor.h
@@ -45,8 +45,6 @@ struct LIBFREENECT2_API RgbPacket
   size_t jpeg_buffer_length;
 };
 
-// explicit instantiation and export to make vsc++ happy
-template class LIBFREENECT2_API PacketProcessor<RgbPacket>;
 typedef PacketProcessor<RgbPacket> BaseRgbPacketProcessor;
 
 class LIBFREENECT2_API RgbPacketProcessor : public BaseRgbPacketProcessor


### PR DESCRIPTION
PR #103 tried to fix a linking issue in Visual Studio 2013 on
Windows 7. It added multiple explicit template instantiations
which violates the standard and results in failure to build
from source on ARM.

Further testing failed to reproduce the linking issue with
Visual Studio 2013 on Windows 8.1. Thus this commit removes
the explicit template instantiations.

This fixes issue #157.