### PR TITLE
Handling race condition for pending_transfers_ and its iterators.

### DIFF
--- a/examples/protonect/include/libfreenect2/usb/transfer_pool.h
+++ b/examples/protonect/include/libfreenect2/usb/transfer_pool.h
@@ -29,6 +29,7 @@
 
 #include <deque>
 #include <libusb.h>
+#include <libfreenect2/threading.h>
 
 #include <libfreenect2/data_callback.h>
 
@@ -70,6 +71,8 @@ private:
   libusb_device_handle *device_handle_;
   unsigned char device_endpoint_;
 
+  mutex pending_transfers_lock_;
+  mutex idle_transfers_lock_;
   TransferQueue idle_transfers_, pending_transfers_;
   unsigned char *buffer_;
   size_t buffer_size_;


### PR DESCRIPTION
I tried updating libusb to the newest master, which due to this commit:
https://github.com/libusb/libusb/commit/a886bb02c87dd5faf271fad595e4622f7027d347

Made a lot more errors on the transfer submitting than I experienced before. After investigating it a bit, I came to the conclusion that there is thread unsafe adding and removing going on, which occasionally made the iterators invalid, since the underlying list/queue had changed.

This pull request adds a mutex to allow only one thread at a time to access the pending_transfer_ list.
Can you verify this @christiankerl?

There might be more places to handle this problem, but for now I'm not experiencing the errors anymore.

I tested with the "older" version of libusb and this addition doesn't seem to break it, nor make any performance loss.

This might be related to the error in #185.