### PR TITLE
Improve RGB and depth stream parsers

### DIFF
--- a/examples/protonect/include/libfreenect2/depth_packet_processor.h
+++ b/examples/protonect/include/libfreenect2/depth_packet_processor.h
@@ -40,6 +40,7 @@ namespace libfreenect2
 struct LIBFREENECT2_API DepthPacket
 {
   uint32_t sequence;
+  uint32_t timestamp;
   unsigned char *buffer;
   size_t buffer_length;
 };

--- a/examples/protonect/include/libfreenect2/frame_listener.hpp
+++ b/examples/protonect/include/libfreenect2/frame_listener.hpp
@@ -28,6 +28,7 @@
 #define FRAME_LISTENER_HPP_
 
 #include <cstddef>
+#include <stdint.h>
 #include <libfreenect2/config.h>
 
 namespace libfreenect2
@@ -42,6 +43,8 @@ struct LIBFREENECT2_API Frame
     Depth = 4
   };
 
+  uint32_t timestamp;
+  uint32_t sequence;
   size_t width, height, bytes_per_pixel;
   unsigned char* data;
 

--- a/examples/protonect/include/libfreenect2/rgb_packet_processor.h
+++ b/examples/protonect/include/libfreenect2/rgb_packet_processor.h
@@ -41,6 +41,7 @@ struct LIBFREENECT2_API RgbPacket
 {
   uint32_t sequence;
 
+  uint32_t timestamp;
   unsigned char *jpeg_buffer;
   size_t jpeg_buffer_length;
 };

--- a/examples/protonect/src/cpu_depth_packet_processor.cpp
+++ b/examples/protonect/src/cpu_depth_packet_processor.cpp
@@ -743,6 +743,11 @@ void CpuDepthPacketProcessor::process(const DepthPacket &packet)
 
   impl_->startTiming();
 
+  impl_->ir_frame->timestamp = packet.timestamp;
+  impl_->depth_frame->timestamp = packet.timestamp;
+  impl_->ir_frame->sequence = packet.sequence;
+  impl_->depth_frame->sequence = packet.sequence;
+
   cv::Mat m = cv::Mat::zeros(424, 512, CV_32FC(9)), m_filtered = cv::Mat::zeros(424, 512, CV_32FC(9)), m_max_edge_test = cv::Mat::ones(424, 512, CV_8UC1);
 
   float *m_ptr = m.ptr<float>();

--- a/examples/protonect/src/depth_packet_stream_parser.cpp
+++ b/examples/protonect/src/depth_packet_stream_parser.cpp
@@ -105,6 +105,7 @@ void DepthPacketStreamParser::onDataReceived(unsigned char* buffer, size_t in_le
 
               DepthPacket packet;
               packet.sequence = current_sequence_;
+              packet.timestamp = footer->timestamp;
               packet.buffer = buffer_.back().data;
               packet.buffer_length = buffer_.back().length;
 

--- a/examples/protonect/src/opencl_depth_packet_processor.cpp
+++ b/examples/protonect/src/opencl_depth_packet_processor.cpp
@@ -653,6 +653,11 @@ void OpenCLDepthPacketProcessor::process(const DepthPacket &packet)
 
   impl_->startTiming();
 
+  impl_->ir_frame->timestamp = packet.timestamp;
+  impl_->depth_frame->timestamp = packet.timestamp;
+  impl_->ir_frame->sequence = packet.sequence;
+  impl_->depth_frame->sequence = packet.sequence;
+
   impl_->run(packet);
 
   impl_->stopTiming();

--- a/examples/protonect/src/opengl_depth_packet_processor.cpp
+++ b/examples/protonect/src/opengl_depth_packet_processor.cpp
@@ -940,6 +940,11 @@ void OpenGLDepthPacketProcessor::process(const DepthPacket &packet)
 
   if(has_listener)
   {
+    ir->timestamp = packet.timestamp;
+    depth->timestamp = packet.timestamp;
+    ir->sequence = packet.sequence;
+    depth->sequence = packet.sequence;
+
     if(!this->listener_->onNewFrame(Frame::Ir, ir))
     {
       delete ir;

--- a/examples/protonect/src/rgb_packet_stream_parser.cpp
+++ b/examples/protonect/src/rgb_packet_stream_parser.cpp
@@ -36,9 +36,27 @@ namespace libfreenect2
 LIBFREENECT2_PACK(struct RawRgbPacket
 {
   uint32_t sequence;
-  uint32_t unknown0;
+  uint32_t magic_header; // is 'BBBB' equal 0x42424242
 
   unsigned char jpeg_buffer[0];
+});
+
+// starting from JPEG EOI: 0xff 0xd9
+// char pad_0xa5[]; //0-3 bytes alignment of 0xa5
+// char filler[filler_length] = "ZZZZ...";
+LIBFREENECT2_PACK(struct RgbPacketFooter {
+  uint32_t magic_header; // is '9999' equal 0x39393939
+  uint32_t sequence;
+  uint32_t filler_length;
+  uint32_t unknown1; // seems 0 always
+  uint32_t unknown2; // seems 0 always
+  uint32_t timestamp;
+  float exposure; // ? ranges from 0.5 to about 60.0 with powerfull light at camera or totally covered
+  float gain; // ? ranges from 1.0 when camera is clear to 1.5 when camera is covered.
+  uint32_t magic_footer; // is 'BBBB' equal 0x42424242
+  uint32_t packet_size;
+  float unknown3; // seems 1.0f always
+  uint32_t unknown4[3]; // seems to be 0 all the time.
 });
 
 RgbPacketStreamParser::RgbPacketStreamParser() :
@@ -71,12 +89,54 @@ void RgbPacketStreamParser::onDataReceived(unsigned char* buffer, size_t length)
     else
     {
       std::cerr << "[RgbPacketStreamParser::onDataReceived] buffer overflow!" << std::endl;
+      fb.length = 0;
+      return;
     }
 
-    // not full transfer buffer and we already have some data -> signals end of rgb image packet
-    // TODO: better method, is unknown0 a magic? detect JPEG magic?
-    if(length < 0x4000 && fb.length > sizeof(RgbPacket))
+    // not enough data to do anything
+    if (fb.length <= sizeof(RawRgbPacket) + sizeof(RgbPacketFooter))
+      return;
+
+    RgbPacketFooter* footer = reinterpret_cast<RgbPacketFooter *>(&fb.data[fb.length - sizeof(RgbPacketFooter)]);
+
+    if (footer->magic_header == 0x39393939 && footer->magic_footer == 0x42424242)
     {
+      RawRgbPacket *raw_packet = reinterpret_cast<RawRgbPacket *>(fb.data);
+
+      if (fb.length != footer->packet_size || raw_packet->sequence != footer->sequence)
+      {
+        std::cerr << "[RgbPacketStreamParser::onDataReceived] packetsize or sequence doesn't match!" << std::endl;
+        fb.length = 0;
+        return;
+      }
+
+      if (fb.length - sizeof(RawRgbPacket) - sizeof(RgbPacketFooter) < footer->filler_length)
+      {
+        std::cerr << "[RgbPacketStreamParser::onDataReceived] not enough space for packet filler!" << std::endl;
+        fb.length = 0;
+        return;
+      }
+
+      size_t jpeg_length = 0;
+      //check for JPEG EOI 0xff 0xd9 within 0 to 3 alignment bytes
+      size_t length_no_filler = fb.length - sizeof(RawRgbPacket) - sizeof(RgbPacketFooter) - footer->filler_length;
+      for (size_t i = 0; i < 4; i++)
+      {
+        if (length_no_filler < i + 2)
+          break;
+        size_t eoi = length_no_filler - i;
+
+        if (raw_packet->jpeg_buffer[eoi - 2] == 0xff && raw_packet->jpeg_buffer[eoi - 1] == 0xd9)
+          jpeg_length = eoi;
+      }
+
+      if (jpeg_length == 0)
+      {
+        std::cerr << "[RgbPacketStreamParser::onDataReceived] no JPEG detected!" << std::endl;
+        fb.length = 0;
+        return;
+      }
+
       // can the processor handle the next image?
       if(processor_->ready())
       {
@@ -87,7 +147,7 @@ void RgbPacketStreamParser::onDataReceived(unsigned char* buffer, size_t length)
         RgbPacket rgb_packet;
         rgb_packet.sequence = raw_packet->sequence;
         rgb_packet.jpeg_buffer = raw_packet->jpeg_buffer;
-        rgb_packet.jpeg_buffer_length = bb.length - sizeof(RawRgbPacket);
+        rgb_packet.jpeg_buffer_length = jpeg_length;
 
         // call the processor
         processor_->process(rgb_packet);

--- a/examples/protonect/src/rgb_packet_stream_parser.cpp
+++ b/examples/protonect/src/rgb_packet_stream_parser.cpp
@@ -146,6 +146,7 @@ void RgbPacketStreamParser::onDataReceived(unsigned char* buffer, size_t length)
         RawRgbPacket *raw_packet = reinterpret_cast<RawRgbPacket *>(bb.data);
         RgbPacket rgb_packet;
         rgb_packet.sequence = raw_packet->sequence;
+        rgb_packet.timestamp = footer->timestamp;
         rgb_packet.jpeg_buffer = raw_packet->jpeg_buffer;
         rgb_packet.jpeg_buffer_length = jpeg_length;
 

--- a/examples/protonect/src/turbo_jpeg_rgb_packet_processor.cpp
+++ b/examples/protonect/src/turbo_jpeg_rgb_packet_processor.cpp
@@ -112,6 +112,9 @@ void TurboJpegRgbPacketProcessor::process(const RgbPacket &packet)
   {
     impl_->startTiming();
 
+    impl_->frame->timestamp = packet.timestamp;
+    impl_->frame->sequence = packet.sequence;
+
     int r = tjDecompress2(impl_->decompressor, packet.jpeg_buffer, packet.jpeg_buffer_length, impl_->frame->data, 1920, 1920 * tjPixelSize[TJPF_BGR], 1080, TJPF_BGR, 0);
 
     if(r == 0)


### PR DESCRIPTION
In the RGB stream parser, add an extra check using information the RGB packet footer revealed by new protocol analysis to detect JPEG EOI marker. Then use the marker's position to derive a correct JPEG length for some hardware JPEG decoders that can't handle garbage after the end of JPEG image.

In the depth stream parser, remove the scanning of a 8-byte magic footer which is very unreliable (the particular 8 bytes may appear in the middle) and inefficient. Based on [analysis of the isochronous transfer protocol](https://github.com/OpenKinect/libfreenect2/pull/75#issuecomment-98205817), assume packets have fixed size and the footer always resides at the end of a fixed sized packet. The changes made are minimized, and the execution order in the original parser is preserved, including the order of memcpy's and subsequence/sequence assembling order.

The code has been tested on Linux and Windows.