### PR TITLE
Use cl_device_type for clGetDeviceInfo(CL_DEVICE_TYPE) instead of size_t...

### DIFF
--- a/examples/protonect/src/opencl_depth_packet_processor.cpp
+++ b/examples/protonect/src/opencl_depth_packet_processor.cpp
@@ -252,7 +252,7 @@ public:
     {
       cl::Device &dev = devices[i];
       std::string devName, devVendor, devType;
-      size_t devTypeID;
+      cl_device_type devTypeID;
       dev.getInfo(CL_DEVICE_NAME, &devName);
       dev.getInfo(CL_DEVICE_VENDOR, &devVendor);
       dev.getInfo(CL_DEVICE_TYPE, &devTypeID);
@@ -293,7 +293,7 @@ public:
     for(size_t i = 0; i < devices.size(); ++i)
     {
       cl::Device &dev = devices[i];
-      size_t devTypeID;
+      cl_device_type devTypeID;
       dev.getInfo(CL_DEVICE_TYPE, &devTypeID);
 
       if(!selected || (selectedType != CL_DEVICE_TYPE_GPU && devTypeID == CL_DEVICE_TYPE_GPU))
@@ -334,7 +334,7 @@ public:
       if(selectDevice(devices, deviceId))
       {
         std::string devName, devVendor, devType;
-        size_t devTypeID;
+        cl_device_type devTypeID;
         device.getInfo(CL_DEVICE_NAME, &devName);
         device.getInfo(CL_DEVICE_VENDOR, &devVendor);
         device.getInfo(CL_DEVICE_TYPE, &devTypeID);


### PR DESCRIPTION
Use cl_device_type for clGetDeviceInfo(CL_DEVICE_TYPE) instead of size_t.

Cl_device_type is defined as 64bit long in OpenCL headers while size of size_t vary depending on platform and compile environment. In some 32bit architecture, at least Mac OS 10.9 i386, that causes like the runtime error below:

[OpenCLDepthPacketProcessor::listDevice]  devices:
[OpenCLDepthPacketProcessor::init] ERROR: clGetDeviceInfo(-30)
libc++abi.dylib: terminating with uncaught exception of type cl::Error: clGetDeviceInfo

This patch fixes the problem. While I've tested this on my Mac only, it looks sane and just modification following to the OpenCL API document.