### PR TITLE
Extension of Protonect to allow selection of pipeline and device

### DIFF
--- a/examples/protonect/Protonect.cpp
+++ b/examples/protonect/Protonect.cpp
@@ -59,7 +59,12 @@ int main(int argc, char *argv[])
   libfreenect2::Freenect2Device *dev = 0;
   libfreenect2::PacketPipeline *pipeline = 0;
 
-  freenect2.enumerateDevices();
+  if(freenect2.enumerateDevices() == 0)
+  {
+    std::cout << "no device connected!" << std::endl;
+    return -1;
+  }
+
   std::string serial = freenect2.getDefaultDeviceSerialNumber();
 
   for(int argI = 1; argI < argc; ++argI)
@@ -110,14 +115,7 @@ int main(int argc, char *argv[])
 
   if(dev == 0)
   {
-    if(serial.empty())
-    {
-      std::cout << "no device connected or failure opening the default one!" << std::endl;
-    }
-    else
-    {
-      std::cout << "could not open device with serial: " << serial << "!" << std::endl;
-    }
+    std::cout << "failure opening device!" << std::endl;
     return -1;
   }
 


### PR DESCRIPTION
I just added some code to `Protonect` to allow the selection of the pipeline and the device via parameters. This makes it easier to check whether certain pipelines work on a system or not. Without any parameters it behaves like before.

Usage: `./Protonect [pipeline] [serial]` (the order don't matter)
Parameters for the pipelines are: `cpu`, `gl`, `cl`
Every parameter that just contains numbers is used as serial number: `012345678901` for example.