### PR TITLE
Added filtering of shadowed color regions to registration

### DIFF
--- a/examples/protonect/Protonect.cpp
+++ b/examples/protonect/Protonect.cpp
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
 
   libfreenect2::SyncMultiFrameListener listener(libfreenect2::Frame::Color | libfreenect2::Frame::Ir | libfreenect2::Frame::Depth);
   libfreenect2::FrameMap frames;
-  libfreenect2::Frame undistorted(512, 424, 4), registered(512, 424, 3);
+  libfreenect2::Frame undistorted(512, 424, 4), registered(512, 424, 4);
 
   dev->setColorFrameListener(&listener);
   dev->setIrAndDepthFrameListener(&listener);
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
     registration->apply(rgb,depth,&undistorted,&registered);
 
     cv::imshow("undistorted", cv::Mat(undistorted.height, undistorted.width, CV_32FC1, undistorted.data) / 4500.0f);
-    cv::imshow("registered", cv::Mat(registered.height, registered.width, CV_8UC3, registered.data));
+    cv::imshow("registered", cv::Mat(registered.height, registered.width, CV_8UC4, registered.data));
 
     int key = cv::waitKey(1);
     protonect_shutdown = protonect_shutdown || (key > 0 && ((key & 0xFF) == 27)); // shutdown on escape

--- a/examples/protonect/Protonect.cpp
+++ b/examples/protonect/Protonect.cpp
@@ -142,7 +142,7 @@ int main(int argc, char *argv[])
     libfreenect2::Frame *ir = frames[libfreenect2::Frame::Ir];
     libfreenect2::Frame *depth = frames[libfreenect2::Frame::Depth];
 
-    cv::imshow("rgb", cv::Mat(rgb->height, rgb->width, CV_8UC3, rgb->data));
+    cv::imshow("rgb", cv::Mat(rgb->height, rgb->width, CV_8UC4, rgb->data));
     cv::imshow("ir", cv::Mat(ir->height, ir->width, CV_32FC1, ir->data) / 20000.0f);
     cv::imshow("depth", cv::Mat(depth->height, depth->width, CV_32FC1, depth->data) / 4500.0f);
 

--- a/examples/protonect/include/libfreenect2/registration.h
+++ b/examples/protonect/include/libfreenect2/registration.h
@@ -44,7 +44,7 @@ public:
   void apply(int dx, int dy, float dz, float& cx, float &cy) const;
 
   // undistort/register a whole image
-  void apply(const Frame* rgb, const Frame* depth, Frame* undistorted, Frame* registered) const;
+  void apply(const Frame* rgb, const Frame* depth, Frame* undistorted, Frame* registered, const bool enable_filter = true) const;
 
 private:
   void distort(int mx, int my, float& dx, float& dy) const;

--- a/examples/protonect/include/libfreenect2/registration.h
+++ b/examples/protonect/include/libfreenect2/registration.h
@@ -57,6 +57,10 @@ private:
   float depth_to_color_map_x[512 * 424];
   float depth_to_color_map_y[512 * 424];
   int depth_to_color_map_yi[512 * 424];
+
+  const int filter_width_half;
+  const int filter_height_half;
+  const float filter_tolerance;
 };
 
 } /* namespace libfreenect2 */

--- a/examples/protonect/src/turbo_jpeg_rgb_packet_processor.cpp
+++ b/examples/protonect/src/turbo_jpeg_rgb_packet_processor.cpp
@@ -73,7 +73,7 @@ public:
 
   void newFrame()
   {
-    frame = new Frame(1920, 1080, tjPixelSize[TJPF_BGR]);
+    frame = new Frame(1920, 1080, tjPixelSize[TJPF_BGRX]);
   }
 
   void startTiming()
@@ -115,7 +115,7 @@ void TurboJpegRgbPacketProcessor::process(const RgbPacket &packet)
     impl_->frame->timestamp = packet.timestamp;
     impl_->frame->sequence = packet.sequence;
 
-    int r = tjDecompress2(impl_->decompressor, packet.jpeg_buffer, packet.jpeg_buffer_length, impl_->frame->data, 1920, 1920 * tjPixelSize[TJPF_BGR], 1080, TJPF_BGR, 0);
+    int r = tjDecompress2(impl_->decompressor, packet.jpeg_buffer, packet.jpeg_buffer_length, impl_->frame->data, 1920, 1920 * tjPixelSize[TJPF_BGRX], 1080, TJPF_BGRX, 0);
 
     if(r == 0)
     {


### PR DESCRIPTION
Hi,

I tested the registration and it works fine, nice work! But it ran a bit slow on my system, so I decided to improve it. The original version took ~5.1 ms on my system. With this changes it went down to ~1 ms.

I achieved this by replacing the multi dimensional array with a one dimensional one, which is structured similar to the image data. `map[i]` is the value for `depth[i]`, etc. So you only need to walk through the array with a pointer and you are done.

The new maps also include some static multiplications and additions which where computed at runtime before. There is also a new map for y image offsets, to reduce computations while runtime even more.

The rounding of the x coordinate is replaced by `const int cx = rx + 0.5f;`, which should be the same for positive numbers. But all valid x coordinates should be greater equals 0 anyway. To make sure that x is positive, a check for `rx > -0.5f` is added to the if statement below.

The last thing I changed is the API of the `apply` method. I changed the type for the registered image to libfreenect2::Frame, so that it is possible to check for the correct size.