### PR TITLE
Make install script abort on errors

### DIFF
--- a/depends/install_deps.sh
+++ b/depends/install_deps.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 cd `dirname $0`
 DEPENDS_DIR=`pwd`


### PR DESCRIPTION
Quick fix to #116.

`install_mac.sh` and `install_ubuntu.sh` don't really have anything that needs this so this is it for now.