### PR TITLE
Fix transfer pool thread safety

### DIFF
--- a/examples/protonect/src/libfreenect2.cpp
+++ b/examples/protonect/src/libfreenect2.cpp
@@ -566,10 +566,6 @@ void Freenect2DeviceImpl::stop()
   rgb_transfer_pool_.cancel();
   ir_transfer_pool_.cancel();
 
-  // wait for completion of transfer cancelation
-  // TODO: better implementation
-  libfreenect2::this_thread::sleep_for(libfreenect2::chrono::milliseconds(1500));
-
   usb_control_.setIrInterfaceState(UsbControl::Disabled);
 
   CommandTransaction::Result result;


### PR DESCRIPTION
Avoid unsafe access during transfer resubmission by refactoring TransferPool using std::vector. It seems there is no need to maintain a queue for the case when a transfer may temporarily fail and recover. If one transfer fails, it is likely all will fail permanently.

Each transfer is independent during runtime and no lock is needed.

Wait for all transfers during cancellation, when the only lock in the TransferPool protects the counter of stopped transfers. Though coarse-grained, this lock will not have effect on runtime performance.

This has been tested on Linux, Windows, and Mac. No crashes are observed, and shutdown time is reduced.

This PR proposes to subsume #212.