### PR TITLE
Fix compile error in libfreenect2.h

### DIFF
--- a/include/libfreenect2.h
+++ b/include/libfreenect2.h
@@ -52,8 +52,8 @@ struct freenect2_device_attributes {
 /// Not all available resolutions are actually supported for all video formats.
 /// Frame modes may not perfectly match resolutions.
 typedef enum {
-	FREENECT2_RESOLUTION_512x424 = 0
-	FREENECT2_RESOLUTION_1920x1080 = 1
+	FREENECT2_RESOLUTION_512x424 = 0,
+	FREENECT2_RESOLUTION_1920x1080 = 1,
 	FREENECT2_RESOLUTION_DUMMY  = 2147483647, /**< Dummy value to force enum to be 32 bits wide */
 } freenect2_resolution;
 


### PR DESCRIPTION
I'd like to fix this syntax error in include/libfreenect2.h and include the file from my source code while it seems not to be used by anyone else.