### PR TITLE
Fix Ubuntu 14.04 installation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ git clone https://github.com/OpenKinect/libfreenect2.git
 1. Install a bunch of dependencies
 
     ```bash
-sudo apt-get install build-essential libjpeg-turbo8-dev libtool autoconf libudev-dev cmake mesa-common-dev freeglut3-dev libxrandr-dev doxygen libxi-dev libopencv-dev automake
+sudo apt-get install build-essential libturbojpeg libjpeg-turbo8-dev libtool autoconf libudev-dev cmake mesa-common-dev freeglut3-dev libxrandr-dev doxygen libxi-dev libopencv-dev automake
 # sudo apt-get install libturbojpeg0-dev (Debian)
 
 cd libfreenect2/depends

--- a/depends/install_ubuntu.sh
+++ b/depends/install_ubuntu.sh
@@ -8,7 +8,6 @@ ARCH="$(uname -m | grep -q 64 && echo 'amd64' || echo 'i386')"
 # download standalone packages for 14.04 LTS
 wget -N http://archive.ubuntu.com/ubuntu/pool/universe/g/glfw3/libglfw3_3.0.4-1_${ARCH}.deb
 wget -N http://archive.ubuntu.com/ubuntu/pool/universe/g/glfw3/libglfw3-dev_3.0.4-1_${ARCH}.deb
-wget -N http://archive.ubuntu.com/ubuntu/pool/universe/g/glfw3/libglfw3-doc_3.0.4-1_all.deb
 
 sh ./install_libusb.sh
 
@@ -17,7 +16,8 @@ cat <<-EOT
 	Execute the following commands to install the remaining dependencies (if you have not already done so):
 
 	sudo dpkg -i libglfw3*_3.0.4-1_*.deb
-	sudo apt-get install build-essential libjpeg-turbo8-dev libtool autoconf libudev-dev cmake mesa-common-dev freeglut3-dev libxrandr-dev doxygen libxi-dev libopencv-dev automake
+	sudo apt-get install build-essential libturbojpeg libjpeg-turbo8-dev libtool autoconf libudev-dev cmake mesa-common-dev freeglut3-dev libxrandr-dev doxygen libxi-dev libopencv-dev automake
+	sudo apt-get install libturbojpeg0-dev # (Debian)
 
 EOT
 


### PR DESCRIPTION
On Ubuntu 14.04, `libturbojpeg.a` and `turbojpeg.h` are provided by
`libjpeg-turbo8-dev`, and `libturbojpeg.so.0` is provided by
`libturbojpeg`. Both packages are needed for building the shared library.

Also, `libglfw3-doc` requires unrelated dependency `libjs-jquery`.
`libglfw3-doc` is not required for building and can be removed.

The issue details are described in #298.