### PR TITLE
fixed memory leak in openDevice

### DIFF
--- a/examples/protonect/include/libfreenect2/libfreenect2.hpp
+++ b/examples/protonect/include/libfreenect2/libfreenect2.hpp
@@ -106,6 +106,11 @@ public:
   std::string getDeviceSerialNumber(int idx);
   std::string getDefaultDeviceSerialNumber();
 
+  /* Important note:
+   * After passing a PacketPipeline object to libfreenect2 do not use or free the object,
+   * libfreenect2 will take care. If openDevice fails the PacketPipeline object will get
+   * deleted. A new PacketPipeline object has to be created each time a device is opened.
+   */
   Freenect2Device *openDevice(int idx);
   Freenect2Device *openDevice(int idx, const PacketPipeline *factory);
   Freenect2Device *openDevice(const std::string &serial);

--- a/examples/protonect/src/libfreenect2.cpp
+++ b/examples/protonect/src/libfreenect2.cpp
@@ -678,6 +678,7 @@ Freenect2Device *Freenect2::openDevice(int idx, const PacketPipeline *pipeline, 
   if(idx >= num_devices)
   {
     std::cout << "[Freenect2Impl] requested device " << idx << " is not connected!" << std::endl;
+    delete pipeline;
     return device;
   }
 
@@ -688,6 +689,7 @@ Freenect2Device *Freenect2::openDevice(int idx, const PacketPipeline *pipeline, 
   {
     std::cout << "[Freenect2Impl] failed to get device " << PrintBusAndDevice(dev.dev)
         << " (the device may already be open)" << std::endl;
+    delete pipeline;
     return device;
   }
 
@@ -696,6 +698,7 @@ Freenect2Device *Freenect2::openDevice(int idx, const PacketPipeline *pipeline, 
   if(r != LIBUSB_SUCCESS)
   {
     std::cout << "[Freenect2Impl] failed to open Kinect v2 " << PrintBusAndDevice(dev.dev) << "!" << std::endl;
+    delete pipeline;
     return device;
   }
 
@@ -733,6 +736,7 @@ Freenect2Device *Freenect2::openDevice(int idx, const PacketPipeline *pipeline, 
     else if(r != LIBUSB_SUCCESS)
     {
       std::cout << "[Freenect2Impl] failed to reset Kinect v2 " << PrintBusAndDevice(dev.dev) << "!" << std::endl;
+      delete pipeline;
       return device;
     }
   }
@@ -765,11 +769,11 @@ Freenect2Device *Freenect2::openDevice(const std::string &serial, const PacketPi
   {
     if(impl_->enumerated_devices_[idx].serial == serial)
     {
-      device = openDevice(idx, pipeline);
-      break;
+      return openDevice(idx, pipeline);
     }
   }
 
+  delete pipeline;
   return device;
 }
 


### PR DESCRIPTION
There is a memory leak in `Freenect2::openDevice`.
If it fails before [line 740](https://github.com/OpenKinect/libfreenect2/blob/master/examples/protonect/src/libfreenect2.cpp#L740) the PacketPipeline will not be deleted. It could also happen when passing a wrong serial number.
If it fails after [line 740](https://github.com/OpenKinect/libfreenect2/blob/master/examples/protonect/src/libfreenect2.cpp#L740) the PacketPipeline will be deleted by the destructor of `Freenect2DeviceImpl`.

I added the necessary delete instructions. We should note somewhere in the documentation that libfreenect2 takes over control of the pipeline object (including destruction) and that it should never be used or deleted by user code afterwards.