### PR TITLE
make sure data pointer in Frame object is 64-byte aligned 

### DIFF
--- a/examples/protonect/include/libfreenect2/frame_listener.hpp
+++ b/examples/protonect/include/libfreenect2/frame_listener.hpp
@@ -34,8 +34,9 @@
 namespace libfreenect2
 {
 
-struct LIBFREENECT2_API Frame
+class LIBFREENECT2_API Frame
 {
+  public:
   enum Type
   {
     Color = 1,
@@ -46,7 +47,6 @@ struct LIBFREENECT2_API Frame
   uint32_t timestamp;
   uint32_t sequence;
   size_t width, height, bytes_per_pixel;
-  unsigned char* rawdata;
   unsigned char* data;
 
   Frame(size_t width, size_t height, size_t bytes_per_pixel) :
@@ -54,14 +54,21 @@ struct LIBFREENECT2_API Frame
     height(height),
     bytes_per_pixel(bytes_per_pixel)
   {
-    rawdata = new unsigned char[width * height * bytes_per_pixel + 128];
-    data = (unsigned char*)((unsigned long long)(rawdata+64) & (unsigned long long)(0xFFFFFFFFFFFFFFC0ULL));
+    const size_t alignment = 64;
+    size_t space = width * height * bytes_per_pixel + alignment;
+    rawdata = new unsigned char[space];
+    uintptr_t ptr = reinterpret_cast<uintptr_t>(rawdata);
+    uintptr_t aligned = (ptr - 1u + alignment) & -alignment;
+    data = reinterpret_cast<unsigned char *>(aligned);
   }
 
   ~Frame()
   {
     delete[] rawdata;
   }
+
+  protected:
+  unsigned char* rawdata;
 };
 
 class LIBFREENECT2_API FrameListener

--- a/examples/protonect/include/libfreenect2/frame_listener.hpp
+++ b/examples/protonect/include/libfreenect2/frame_listener.hpp
@@ -29,6 +29,7 @@
 
 #include <cstddef>
 #include <stdint.h>
+#include <stdlib.h>
 #include <libfreenect2/config.h>
 
 namespace libfreenect2
@@ -46,6 +47,7 @@ struct LIBFREENECT2_API Frame
   uint32_t timestamp;
   uint32_t sequence;
   size_t width, height, bytes_per_pixel;
+  unsigned char* rawdata;
   unsigned char* data;
 
   Frame(size_t width, size_t height, size_t bytes_per_pixel) :
@@ -53,12 +55,13 @@ struct LIBFREENECT2_API Frame
     height(height),
     bytes_per_pixel(bytes_per_pixel)
   {
-    data = new unsigned char[width * height * bytes_per_pixel];
+    rawdata = new unsigned char[width * height * bytes_per_pixel + 128];
+    data = (unsigned char*)((unsigned long long)(rawdata+64) & (unsigned long long)(0xFFFFFFFFFFFFFFC0ULL));
   }
 
   ~Frame()
   {
-    delete[] data;
+    delete[] rawdata;
   }
 };
 

--- a/examples/protonect/include/libfreenect2/frame_listener.hpp
+++ b/examples/protonect/include/libfreenect2/frame_listener.hpp
@@ -29,7 +29,6 @@
 
 #include <cstddef>
 #include <stdint.h>
-#include <stdlib.h>
 #include <libfreenect2/config.h>
 
 namespace libfreenect2


### PR DESCRIPTION
When using stuff like SSE/AVX, the data needs to be aligned to 32- (or 64-) byte boundaries. This makes sure that the data pointer in a Frame object conforms to that alignment without needing stuff like `_aligned_malloc`. I don't think this can break anything, but opinions are welcome @christiankerl @xlz 