### PR TITLE
Intel Mesa OpenGL bug fixes and cleanup

### DIFF
--- a/examples/protonect/include/libfreenect2/depth_packet_stream_parser.h
+++ b/examples/protonect/include/libfreenect2/depth_packet_stream_parser.h
@@ -68,6 +68,7 @@ private:
 
   uint32_t current_sequence_;
   uint32_t current_subsequence_;
+  uint32_t processed_packets_;
 };
 
 } /* namespace libfreenect2 */

--- a/examples/protonect/src/command_transaction.cpp
+++ b/examples/protonect/src/command_transaction.cpp
@@ -29,6 +29,8 @@
 
 #include <stdint.h>
 
+#define WRITE_LIBUSB_ERROR(__RESULT) libusb_error_name(__RESULT) << " " << libusb_strerror((libusb_error)__RESULT)
+
 namespace libfreenect2
 {
 namespace protocol
@@ -135,7 +137,7 @@ CommandTransaction::ResultCode CommandTransaction::send(const CommandBase& comma
 
   if(r != LIBUSB_SUCCESS)
   {
-    LOG_ERROR << "bulk transfer failed! libusb error " << r << ": " << libusb_error_name(r);
+    LOG_ERROR << "bulk transfer failed: " << WRITE_LIBUSB_ERROR(r);
     code = Error;
   }
 
@@ -157,7 +159,7 @@ void CommandTransaction::receive(CommandTransaction::Result& result)
 
   if(r != LIBUSB_SUCCESS)
   {
-    LOG_ERROR << "bulk transfer failed! libusb error " << r << ": " << libusb_error_name(r);
+    LOG_ERROR << "bulk transfer failed: " << WRITE_LIBUSB_ERROR(r);
     result.code = Error;
   }
 }

--- a/examples/protonect/src/flextGL.c
+++ b/examples/protonect/src/flextGL.c
@@ -24,8 +24,8 @@ int flextInit(GLFWwindow* window, OpenGLBindings *bindings)
     
     /* --- Check for minimal version and profile --- */
 
-    if (major * 10 + minor < 33) {
-        fprintf(stderr, "Error: OpenGL version 3.3 not supported.\n");
+    if (major * 10 + minor < 31) {
+        fprintf(stderr, "Error: OpenGL version 3.1 not supported.\n");
         fprintf(stderr, "       Your version is %d.%d.\n", major, minor);
         fprintf(stderr, "       Try updating your graphics driver.\n");
         return GL_FALSE;
@@ -306,7 +306,7 @@ void flextLoadOpenGLFunctions(OpenGLBindings *bindings)
     bindings->glUniformBlockBinding = (PFNGLUNIFORMBLOCKBINDING_PROC*)glfwGetProcAddress("glUniformBlockBinding");
 
     /* GL_VERSION_3_2 */
-
+/*
     bindings->glDrawElementsBaseVertex = (PFNGLDRAWELEMENTSBASEVERTEX_PROC*)glfwGetProcAddress("glDrawElementsBaseVertex");
     bindings->glDrawRangeElementsBaseVertex = (PFNGLDRAWRANGEELEMENTSBASEVERTEX_PROC*)glfwGetProcAddress("glDrawRangeElementsBaseVertex");
     bindings->glDrawElementsInstancedBaseVertex = (PFNGLDRAWELEMENTSINSTANCEDBASEVERTEX_PROC*)glfwGetProcAddress("glDrawElementsInstancedBaseVertex");
@@ -326,9 +326,9 @@ void flextLoadOpenGLFunctions(OpenGLBindings *bindings)
     bindings->glTexImage3DMultisample = (PFNGLTEXIMAGE3DMULTISAMPLE_PROC*)glfwGetProcAddress("glTexImage3DMultisample");
     bindings->glGetMultisamplefv = (PFNGLGETMULTISAMPLEFV_PROC*)glfwGetProcAddress("glGetMultisamplefv");
     bindings->glSampleMaski = (PFNGLSAMPLEMASKI_PROC*)glfwGetProcAddress("glSampleMaski");
-
+*/
     /* GL_VERSION_3_3 */
-
+/*
     bindings->glBindFragDataLocationIndexed = (PFNGLBINDFRAGDATALOCATIONINDEXED_PROC*)glfwGetProcAddress("glBindFragDataLocationIndexed");
     bindings->glGetFragDataIndex = (PFNGLGETFRAGDATAINDEX_PROC*)glfwGetProcAddress("glGetFragDataIndex");
     bindings->glGenSamplers = (PFNGLGENSAMPLERS_PROC*)glfwGetProcAddress("glGenSamplers");
@@ -357,7 +357,7 @@ void flextLoadOpenGLFunctions(OpenGLBindings *bindings)
     bindings->glVertexAttribP3uiv = (PFNGLVERTEXATTRIBP3UIV_PROC*)glfwGetProcAddress("glVertexAttribP3uiv");
     bindings->glVertexAttribP4ui = (PFNGLVERTEXATTRIBP4UI_PROC*)glfwGetProcAddress("glVertexAttribP4ui");
     bindings->glVertexAttribP4uiv = (PFNGLVERTEXATTRIBP4UIV_PROC*)glfwGetProcAddress("glVertexAttribP4uiv");
-
+*/
 }
 
 /* ----------------------- Extension flag definitions ---------------------- */

--- a/examples/protonect/src/flextGL.c
+++ b/examples/protonect/src/flextGL.c
@@ -1,46 +1,11 @@
-/* WARNING: This file was automatically generated */
-/* Do not edit. */
-
 #include "flextGL.h"
 #include "GLFW/glfw3.h"
-
-#include <stdio.h>
-
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
-void flextLoadOpenGLFunctions(OpenGLBindings *bindings);
-
-int flextInit(GLFWwindow* window, OpenGLBindings *bindings)
-{
-  
-    int major = glfwGetWindowAttrib(window, GLFW_CONTEXT_VERSION_MAJOR);
-    int minor = glfwGetWindowAttrib(window, GLFW_CONTEXT_VERSION_MINOR);
-
-    flextLoadOpenGLFunctions(bindings);
-    
-    /* --- Check for minimal version and profile --- */
-
-    if (major * 10 + minor < 31) {
-        fprintf(stderr, "Error: OpenGL version 3.1 not supported.\n");
-        fprintf(stderr, "       Your version is %d.%d.\n", major, minor);
-        fprintf(stderr, "       Try updating your graphics driver.\n");
-        return GL_FALSE;
-    }
-
-
-    /* --- Check for extensions --- */
-
-
-    return GL_TRUE;
-}
-
-
-
-void flextLoadOpenGLFunctions(OpenGLBindings *bindings)
+void flextInit(OpenGLBindings *bindings)
 {
     /* --- Function pointer loading --- */
 
@@ -305,59 +270,6 @@ void flextLoadOpenGLFunctions(OpenGLBindings *bindings)
     bindings->glGetActiveUniformBlockName = (PFNGLGETACTIVEUNIFORMBLOCKNAME_PROC*)glfwGetProcAddress("glGetActiveUniformBlockName");
     bindings->glUniformBlockBinding = (PFNGLUNIFORMBLOCKBINDING_PROC*)glfwGetProcAddress("glUniformBlockBinding");
 
-    /* GL_VERSION_3_2 */
-/*
-    bindings->glDrawElementsBaseVertex = (PFNGLDRAWELEMENTSBASEVERTEX_PROC*)glfwGetProcAddress("glDrawElementsBaseVertex");
-    bindings->glDrawRangeElementsBaseVertex = (PFNGLDRAWRANGEELEMENTSBASEVERTEX_PROC*)glfwGetProcAddress("glDrawRangeElementsBaseVertex");
-    bindings->glDrawElementsInstancedBaseVertex = (PFNGLDRAWELEMENTSINSTANCEDBASEVERTEX_PROC*)glfwGetProcAddress("glDrawElementsInstancedBaseVertex");
-    bindings->glMultiDrawElementsBaseVertex = (PFNGLMULTIDRAWELEMENTSBASEVERTEX_PROC*)glfwGetProcAddress("glMultiDrawElementsBaseVertex");
-    bindings->glProvokingVertex = (PFNGLPROVOKINGVERTEX_PROC*)glfwGetProcAddress("glProvokingVertex");
-    bindings->glFenceSync = (PFNGLFENCESYNC_PROC*)glfwGetProcAddress("glFenceSync");
-    bindings->glIsSync = (PFNGLISSYNC_PROC*)glfwGetProcAddress("glIsSync");
-    bindings->glDeleteSync = (PFNGLDELETESYNC_PROC*)glfwGetProcAddress("glDeleteSync");
-    bindings->glClientWaitSync = (PFNGLCLIENTWAITSYNC_PROC*)glfwGetProcAddress("glClientWaitSync");
-    bindings->glWaitSync = (PFNGLWAITSYNC_PROC*)glfwGetProcAddress("glWaitSync");
-    bindings->glGetInteger64v = (PFNGLGETINTEGER64V_PROC*)glfwGetProcAddress("glGetInteger64v");
-    bindings->glGetSynciv = (PFNGLGETSYNCIV_PROC*)glfwGetProcAddress("glGetSynciv");
-    bindings->glGetInteger64i_v = (PFNGLGETINTEGER64I_V_PROC*)glfwGetProcAddress("glGetInteger64i_v");
-    bindings->glGetBufferParameteri64v = (PFNGLGETBUFFERPARAMETERI64V_PROC*)glfwGetProcAddress("glGetBufferParameteri64v");
-    bindings->glFramebufferTexture = (PFNGLFRAMEBUFFERTEXTURE_PROC*)glfwGetProcAddress("glFramebufferTexture");
-    bindings->glTexImage2DMultisample = (PFNGLTEXIMAGE2DMULTISAMPLE_PROC*)glfwGetProcAddress("glTexImage2DMultisample");
-    bindings->glTexImage3DMultisample = (PFNGLTEXIMAGE3DMULTISAMPLE_PROC*)glfwGetProcAddress("glTexImage3DMultisample");
-    bindings->glGetMultisamplefv = (PFNGLGETMULTISAMPLEFV_PROC*)glfwGetProcAddress("glGetMultisamplefv");
-    bindings->glSampleMaski = (PFNGLSAMPLEMASKI_PROC*)glfwGetProcAddress("glSampleMaski");
-*/
-    /* GL_VERSION_3_3 */
-/*
-    bindings->glBindFragDataLocationIndexed = (PFNGLBINDFRAGDATALOCATIONINDEXED_PROC*)glfwGetProcAddress("glBindFragDataLocationIndexed");
-    bindings->glGetFragDataIndex = (PFNGLGETFRAGDATAINDEX_PROC*)glfwGetProcAddress("glGetFragDataIndex");
-    bindings->glGenSamplers = (PFNGLGENSAMPLERS_PROC*)glfwGetProcAddress("glGenSamplers");
-    bindings->glDeleteSamplers = (PFNGLDELETESAMPLERS_PROC*)glfwGetProcAddress("glDeleteSamplers");
-    bindings->glIsSampler = (PFNGLISSAMPLER_PROC*)glfwGetProcAddress("glIsSampler");
-    bindings->glBindSampler = (PFNGLBINDSAMPLER_PROC*)glfwGetProcAddress("glBindSampler");
-    bindings->glSamplerParameteri = (PFNGLSAMPLERPARAMETERI_PROC*)glfwGetProcAddress("glSamplerParameteri");
-    bindings->glSamplerParameteriv = (PFNGLSAMPLERPARAMETERIV_PROC*)glfwGetProcAddress("glSamplerParameteriv");
-    bindings->glSamplerParameterf = (PFNGLSAMPLERPARAMETERF_PROC*)glfwGetProcAddress("glSamplerParameterf");
-    bindings->glSamplerParameterfv = (PFNGLSAMPLERPARAMETERFV_PROC*)glfwGetProcAddress("glSamplerParameterfv");
-    bindings->glSamplerParameterIiv = (PFNGLSAMPLERPARAMETERIIV_PROC*)glfwGetProcAddress("glSamplerParameterIiv");
-    bindings->glSamplerParameterIuiv = (PFNGLSAMPLERPARAMETERIUIV_PROC*)glfwGetProcAddress("glSamplerParameterIuiv");
-    bindings->glGetSamplerParameteriv = (PFNGLGETSAMPLERPARAMETERIV_PROC*)glfwGetProcAddress("glGetSamplerParameteriv");
-    bindings->glGetSamplerParameterIiv = (PFNGLGETSAMPLERPARAMETERIIV_PROC*)glfwGetProcAddress("glGetSamplerParameterIiv");
-    bindings->glGetSamplerParameterfv = (PFNGLGETSAMPLERPARAMETERFV_PROC*)glfwGetProcAddress("glGetSamplerParameterfv");
-    bindings->glGetSamplerParameterIuiv = (PFNGLGETSAMPLERPARAMETERIUIV_PROC*)glfwGetProcAddress("glGetSamplerParameterIuiv");
-    bindings->glQueryCounter = (PFNGLQUERYCOUNTER_PROC*)glfwGetProcAddress("glQueryCounter");
-    bindings->glGetQueryObjecti64v = (PFNGLGETQUERYOBJECTI64V_PROC*)glfwGetProcAddress("glGetQueryObjecti64v");
-    bindings->glGetQueryObjectui64v = (PFNGLGETQUERYOBJECTUI64V_PROC*)glfwGetProcAddress("glGetQueryObjectui64v");
-    bindings->glVertexAttribDivisor = (PFNGLVERTEXATTRIBDIVISOR_PROC*)glfwGetProcAddress("glVertexAttribDivisor");
-    bindings->glVertexAttribP1ui = (PFNGLVERTEXATTRIBP1UI_PROC*)glfwGetProcAddress("glVertexAttribP1ui");
-    bindings->glVertexAttribP1uiv = (PFNGLVERTEXATTRIBP1UIV_PROC*)glfwGetProcAddress("glVertexAttribP1uiv");
-    bindings->glVertexAttribP2ui = (PFNGLVERTEXATTRIBP2UI_PROC*)glfwGetProcAddress("glVertexAttribP2ui");
-    bindings->glVertexAttribP2uiv = (PFNGLVERTEXATTRIBP2UIV_PROC*)glfwGetProcAddress("glVertexAttribP2uiv");
-    bindings->glVertexAttribP3ui = (PFNGLVERTEXATTRIBP3UI_PROC*)glfwGetProcAddress("glVertexAttribP3ui");
-    bindings->glVertexAttribP3uiv = (PFNGLVERTEXATTRIBP3UIV_PROC*)glfwGetProcAddress("glVertexAttribP3uiv");
-    bindings->glVertexAttribP4ui = (PFNGLVERTEXATTRIBP4UI_PROC*)glfwGetProcAddress("glVertexAttribP4ui");
-    bindings->glVertexAttribP4uiv = (PFNGLVERTEXATTRIBP4UIV_PROC*)glfwGetProcAddress("glVertexAttribP4uiv");
-*/
 }
 
 /* ----------------------- Extension flag definitions ---------------------- */

--- a/examples/protonect/src/flextGL.h
+++ b/examples/protonect/src/flextGL.h
@@ -1,6 +1,3 @@
-/* WARNING: This file was automatically generated */
-/* Do not edit. */
-
 #ifndef __gl_h_
 #define __gl_h_
 
@@ -840,92 +837,6 @@ typedef struct __GLsync *GLsync;
 #define GL_UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER 0x8A46
 #define GL_INVALID_INDEX 0xFFFFFFFFu
 
-/* GL_VERSION_3_2 */
-/*
-#define GL_CONTEXT_CORE_PROFILE_BIT 0x00000001
-#define GL_CONTEXT_COMPATIBILITY_PROFILE_BIT 0x00000002
-#define GL_LINES_ADJACENCY 0x000A
-#define GL_LINE_STRIP_ADJACENCY 0x000B
-#define GL_TRIANGLES_ADJACENCY 0x000C
-#define GL_TRIANGLE_STRIP_ADJACENCY 0x000D
-#define GL_PROGRAM_POINT_SIZE 0x8642
-#define GL_MAX_GEOMETRY_TEXTURE_IMAGE_UNITS 0x8C29
-#define GL_FRAMEBUFFER_ATTACHMENT_LAYERED 0x8DA7
-#define GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS 0x8DA8
-#define GL_GEOMETRY_SHADER 0x8DD9
-#define GL_GEOMETRY_VERTICES_OUT 0x8916
-#define GL_GEOMETRY_INPUT_TYPE 0x8917
-#define GL_GEOMETRY_OUTPUT_TYPE 0x8918
-#define GL_MAX_GEOMETRY_UNIFORM_COMPONENTS 0x8DDF
-#define GL_MAX_GEOMETRY_OUTPUT_VERTICES 0x8DE0
-#define GL_MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS 0x8DE1
-#define GL_MAX_VERTEX_OUTPUT_COMPONENTS 0x9122
-#define GL_MAX_GEOMETRY_INPUT_COMPONENTS 0x9123
-#define GL_MAX_GEOMETRY_OUTPUT_COMPONENTS 0x9124
-#define GL_MAX_FRAGMENT_INPUT_COMPONENTS 0x9125
-#define GL_CONTEXT_PROFILE_MASK 0x9126
-#define GL_DEPTH_CLAMP 0x864F
-#define GL_QUADS_FOLLOW_PROVOKING_VERTEX_CONVENTION 0x8E4C
-#define GL_FIRST_VERTEX_CONVENTION 0x8E4D
-#define GL_LAST_VERTEX_CONVENTION 0x8E4E
-#define GL_PROVOKING_VERTEX 0x8E4F
-#define GL_TEXTURE_CUBE_MAP_SEAMLESS 0x884F
-#define GL_MAX_SERVER_WAIT_TIMEOUT 0x9111
-#define GL_OBJECT_TYPE 0x9112
-#define GL_SYNC_CONDITION 0x9113
-#define GL_SYNC_STATUS 0x9114
-#define GL_SYNC_FLAGS 0x9115
-#define GL_SYNC_FENCE 0x9116
-#define GL_SYNC_GPU_COMMANDS_COMPLETE 0x9117
-#define GL_UNSIGNALED 0x9118
-#define GL_SIGNALED 0x9119
-#define GL_ALREADY_SIGNALED 0x911A
-#define GL_TIMEOUT_EXPIRED 0x911B
-#define GL_CONDITION_SATISFIED 0x911C
-#define GL_WAIT_FAILED 0x911D
-#define GL_TIMEOUT_IGNORED 0xFFFFFFFFFFFFFFFFull
-#define GL_SYNC_FLUSH_COMMANDS_BIT 0x00000001
-#define GL_SAMPLE_POSITION 0x8E50
-#define GL_SAMPLE_MASK 0x8E51
-#define GL_SAMPLE_MASK_VALUE 0x8E52
-#define GL_MAX_SAMPLE_MASK_WORDS 0x8E59
-#define GL_TEXTURE_2D_MULTISAMPLE 0x9100
-#define GL_PROXY_TEXTURE_2D_MULTISAMPLE 0x9101
-#define GL_TEXTURE_2D_MULTISAMPLE_ARRAY 0x9102
-#define GL_PROXY_TEXTURE_2D_MULTISAMPLE_ARRAY 0x9103
-#define GL_TEXTURE_BINDING_2D_MULTISAMPLE 0x9104
-#define GL_TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY 0x9105
-#define GL_TEXTURE_SAMPLES 0x9106
-#define GL_TEXTURE_FIXED_SAMPLE_LOCATIONS 0x9107
-#define GL_SAMPLER_2D_MULTISAMPLE 0x9108
-#define GL_INT_SAMPLER_2D_MULTISAMPLE 0x9109
-#define GL_UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE 0x910A
-#define GL_SAMPLER_2D_MULTISAMPLE_ARRAY 0x910B
-#define GL_INT_SAMPLER_2D_MULTISAMPLE_ARRAY 0x910C
-#define GL_UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE_ARRAY 0x910D
-#define GL_MAX_COLOR_TEXTURE_SAMPLES 0x910E
-#define GL_MAX_DEPTH_TEXTURE_SAMPLES 0x910F
-#define GL_MAX_INTEGER_SAMPLES 0x9110
-*/
-/* GL_VERSION_3_3 */
-/*
-#define GL_VERTEX_ATTRIB_ARRAY_DIVISOR 0x88FE
-#define GL_SRC1_COLOR 0x88F9
-#define GL_ONE_MINUS_SRC1_COLOR 0x88FA
-#define GL_ONE_MINUS_SRC1_ALPHA 0x88FB
-#define GL_MAX_DUAL_SOURCE_DRAW_BUFFERS 0x88FC
-#define GL_ANY_SAMPLES_PASSED 0x8C2F
-#define GL_SAMPLER_BINDING 0x8919
-#define GL_RGB10_A2UI 0x906F
-#define GL_TEXTURE_SWIZZLE_R 0x8E42
-#define GL_TEXTURE_SWIZZLE_G 0x8E43
-#define GL_TEXTURE_SWIZZLE_B 0x8E44
-#define GL_TEXTURE_SWIZZLE_A 0x8E45
-#define GL_TEXTURE_SWIZZLE_RGBA 0x8E46
-#define GL_TIME_ELAPSED 0x88BF
-#define GL_TIMESTAMP 0x8E28
-#define GL_INT_2_10_10_10_REV 0x8D9F
-*/
 /* --------------------------- FUNCTION PROTOTYPES --------------------------- */
 
     
@@ -1257,59 +1168,6 @@ typedef void (APIENTRY PFNGLGETACTIVEUNIFORMBLOCKIV_PROC (GLuint program, GLuint
 typedef void (APIENTRY PFNGLGETACTIVEUNIFORMBLOCKNAME_PROC (GLuint program, GLuint uniformBlockIndex, GLsizei bufSize, GLsizei * length, GLchar * uniformBlockName));
 typedef void (APIENTRY PFNGLUNIFORMBLOCKBINDING_PROC (GLuint program, GLuint uniformBlockIndex, GLuint uniformBlockBinding));
     
-/* GL_VERSION_3_2 */
-/*
-typedef void (APIENTRY PFNGLDRAWELEMENTSBASEVERTEX_PROC (GLenum mode, GLsizei count, GLenum type, const void * indices, GLint basevertex));
-typedef void (APIENTRY PFNGLDRAWRANGEELEMENTSBASEVERTEX_PROC (GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, const void * indices, GLint basevertex));
-typedef void (APIENTRY PFNGLDRAWELEMENTSINSTANCEDBASEVERTEX_PROC (GLenum mode, GLsizei count, GLenum type, const void * indices, GLsizei instancecount, GLint basevertex));
-typedef void (APIENTRY PFNGLMULTIDRAWELEMENTSBASEVERTEX_PROC (GLenum mode, const GLsizei * count, GLenum type, const void *const* indices, GLsizei drawcount, const GLint * basevertex));
-typedef void (APIENTRY PFNGLPROVOKINGVERTEX_PROC (GLenum mode));
-typedef GLsync (APIENTRY PFNGLFENCESYNC_PROC (GLenum condition, GLbitfield flags));
-typedef GLboolean (APIENTRY PFNGLISSYNC_PROC (GLsync sync));
-typedef void (APIENTRY PFNGLDELETESYNC_PROC (GLsync sync));
-typedef GLenum (APIENTRY PFNGLCLIENTWAITSYNC_PROC (GLsync sync, GLbitfield flags, GLuint64 timeout));
-typedef void (APIENTRY PFNGLWAITSYNC_PROC (GLsync sync, GLbitfield flags, GLuint64 timeout));
-typedef void (APIENTRY PFNGLGETINTEGER64V_PROC (GLenum pname, GLint64 * data));
-typedef void (APIENTRY PFNGLGETSYNCIV_PROC (GLsync sync, GLenum pname, GLsizei bufSize, GLsizei * length, GLint * values));
-typedef void (APIENTRY PFNGLGETINTEGER64I_V_PROC (GLenum target, GLuint index, GLint64 * data));
-typedef void (APIENTRY PFNGLGETBUFFERPARAMETERI64V_PROC (GLenum target, GLenum pname, GLint64 * params));
-typedef void (APIENTRY PFNGLFRAMEBUFFERTEXTURE_PROC (GLenum target, GLenum attachment, GLuint texture, GLint level));
-typedef void (APIENTRY PFNGLTEXIMAGE2DMULTISAMPLE_PROC (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height, GLboolean fixedsamplelocations));
-typedef void (APIENTRY PFNGLTEXIMAGE3DMULTISAMPLE_PROC (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLboolean fixedsamplelocations));
-typedef void (APIENTRY PFNGLGETMULTISAMPLEFV_PROC (GLenum pname, GLuint index, GLfloat * val));
-typedef void (APIENTRY PFNGLSAMPLEMASKI_PROC (GLuint maskNumber, GLbitfield mask));
-*/
-/* GL_VERSION_3_3 */
-/*
-typedef void (APIENTRY PFNGLBINDFRAGDATALOCATIONINDEXED_PROC (GLuint program, GLuint colorNumber, GLuint index, const GLchar * name));
-typedef GLint (APIENTRY PFNGLGETFRAGDATAINDEX_PROC (GLuint program, const GLchar * name));
-typedef void (APIENTRY PFNGLGENSAMPLERS_PROC (GLsizei count, GLuint * samplers));
-typedef void (APIENTRY PFNGLDELETESAMPLERS_PROC (GLsizei count, const GLuint * samplers));
-typedef GLboolean (APIENTRY PFNGLISSAMPLER_PROC (GLuint sampler));
-typedef void (APIENTRY PFNGLBINDSAMPLER_PROC (GLuint unit, GLuint sampler));
-typedef void (APIENTRY PFNGLSAMPLERPARAMETERI_PROC (GLuint sampler, GLenum pname, GLint param));
-typedef void (APIENTRY PFNGLSAMPLERPARAMETERIV_PROC (GLuint sampler, GLenum pname, const GLint * param));
-typedef void (APIENTRY PFNGLSAMPLERPARAMETERF_PROC (GLuint sampler, GLenum pname, GLfloat param));
-typedef void (APIENTRY PFNGLSAMPLERPARAMETERFV_PROC (GLuint sampler, GLenum pname, const GLfloat * param));
-typedef void (APIENTRY PFNGLSAMPLERPARAMETERIIV_PROC (GLuint sampler, GLenum pname, const GLint * param));
-typedef void (APIENTRY PFNGLSAMPLERPARAMETERIUIV_PROC (GLuint sampler, GLenum pname, const GLuint * param));
-typedef void (APIENTRY PFNGLGETSAMPLERPARAMETERIV_PROC (GLuint sampler, GLenum pname, GLint * params));
-typedef void (APIENTRY PFNGLGETSAMPLERPARAMETERIIV_PROC (GLuint sampler, GLenum pname, GLint * params));
-typedef void (APIENTRY PFNGLGETSAMPLERPARAMETERFV_PROC (GLuint sampler, GLenum pname, GLfloat * params));
-typedef void (APIENTRY PFNGLGETSAMPLERPARAMETERIUIV_PROC (GLuint sampler, GLenum pname, GLuint * params));
-typedef void (APIENTRY PFNGLQUERYCOUNTER_PROC (GLuint id, GLenum target));
-typedef void (APIENTRY PFNGLGETQUERYOBJECTI64V_PROC (GLuint id, GLenum pname, GLint64 * params));
-typedef void (APIENTRY PFNGLGETQUERYOBJECTUI64V_PROC (GLuint id, GLenum pname, GLuint64 * params));
-typedef void (APIENTRY PFNGLVERTEXATTRIBDIVISOR_PROC (GLuint index, GLuint divisor));
-typedef void (APIENTRY PFNGLVERTEXATTRIBP1UI_PROC (GLuint index, GLenum type, GLboolean normalized, GLuint value));
-typedef void (APIENTRY PFNGLVERTEXATTRIBP1UIV_PROC (GLuint index, GLenum type, GLboolean normalized, const GLuint * value));
-typedef void (APIENTRY PFNGLVERTEXATTRIBP2UI_PROC (GLuint index, GLenum type, GLboolean normalized, GLuint value));
-typedef void (APIENTRY PFNGLVERTEXATTRIBP2UIV_PROC (GLuint index, GLenum type, GLboolean normalized, const GLuint * value));
-typedef void (APIENTRY PFNGLVERTEXATTRIBP3UI_PROC (GLuint index, GLenum type, GLboolean normalized, GLuint value));
-typedef void (APIENTRY PFNGLVERTEXATTRIBP3UIV_PROC (GLuint index, GLenum type, GLboolean normalized, const GLuint * value));
-typedef void (APIENTRY PFNGLVERTEXATTRIBP4UI_PROC (GLuint index, GLenum type, GLboolean normalized, GLuint value));
-typedef void (APIENTRY PFNGLVERTEXATTRIBP4UIV_PROC (GLuint index, GLenum type, GLboolean normalized, const GLuint * value));
-*/
 struct OpenGLBindings
 {
     
@@ -1573,59 +1431,6 @@ struct OpenGLBindings
   PFNGLGETACTIVEUNIFORMBLOCKNAME_PROC* glGetActiveUniformBlockName;
   PFNGLUNIFORMBLOCKBINDING_PROC* glUniformBlockBinding;
     
-  /* GL_VERSION_3_2 */
-/*
-  PFNGLDRAWELEMENTSBASEVERTEX_PROC* glDrawElementsBaseVertex;
-  PFNGLDRAWRANGEELEMENTSBASEVERTEX_PROC* glDrawRangeElementsBaseVertex;
-  PFNGLDRAWELEMENTSINSTANCEDBASEVERTEX_PROC* glDrawElementsInstancedBaseVertex;
-  PFNGLMULTIDRAWELEMENTSBASEVERTEX_PROC* glMultiDrawElementsBaseVertex;
-  PFNGLPROVOKINGVERTEX_PROC* glProvokingVertex;
-  PFNGLFENCESYNC_PROC* glFenceSync;
-  PFNGLISSYNC_PROC* glIsSync;
-  PFNGLDELETESYNC_PROC* glDeleteSync;
-  PFNGLCLIENTWAITSYNC_PROC* glClientWaitSync;
-  PFNGLWAITSYNC_PROC* glWaitSync;
-  PFNGLGETINTEGER64V_PROC* glGetInteger64v;
-  PFNGLGETSYNCIV_PROC* glGetSynciv;
-  PFNGLGETINTEGER64I_V_PROC* glGetInteger64i_v;
-  PFNGLGETBUFFERPARAMETERI64V_PROC* glGetBufferParameteri64v;
-  PFNGLFRAMEBUFFERTEXTURE_PROC* glFramebufferTexture;
-  PFNGLTEXIMAGE2DMULTISAMPLE_PROC* glTexImage2DMultisample;
-  PFNGLTEXIMAGE3DMULTISAMPLE_PROC* glTexImage3DMultisample;
-  PFNGLGETMULTISAMPLEFV_PROC* glGetMultisamplefv;
-  PFNGLSAMPLEMASKI_PROC* glSampleMaski;
-*/
-  /* GL_VERSION_3_3 */
-/*
-  PFNGLBINDFRAGDATALOCATIONINDEXED_PROC* glBindFragDataLocationIndexed;
-  PFNGLGETFRAGDATAINDEX_PROC* glGetFragDataIndex;
-  PFNGLGENSAMPLERS_PROC* glGenSamplers;
-  PFNGLDELETESAMPLERS_PROC* glDeleteSamplers;
-  PFNGLISSAMPLER_PROC* glIsSampler;
-  PFNGLBINDSAMPLER_PROC* glBindSampler;
-  PFNGLSAMPLERPARAMETERI_PROC* glSamplerParameteri;
-  PFNGLSAMPLERPARAMETERIV_PROC* glSamplerParameteriv;
-  PFNGLSAMPLERPARAMETERF_PROC* glSamplerParameterf;
-  PFNGLSAMPLERPARAMETERFV_PROC* glSamplerParameterfv;
-  PFNGLSAMPLERPARAMETERIIV_PROC* glSamplerParameterIiv;
-  PFNGLSAMPLERPARAMETERIUIV_PROC* glSamplerParameterIuiv;
-  PFNGLGETSAMPLERPARAMETERIV_PROC* glGetSamplerParameteriv;
-  PFNGLGETSAMPLERPARAMETERIIV_PROC* glGetSamplerParameterIiv;
-  PFNGLGETSAMPLERPARAMETERFV_PROC* glGetSamplerParameterfv;
-  PFNGLGETSAMPLERPARAMETERIUIV_PROC* glGetSamplerParameterIuiv;
-  PFNGLQUERYCOUNTER_PROC* glQueryCounter;
-  PFNGLGETQUERYOBJECTI64V_PROC* glGetQueryObjecti64v;
-  PFNGLGETQUERYOBJECTUI64V_PROC* glGetQueryObjectui64v;
-  PFNGLVERTEXATTRIBDIVISOR_PROC* glVertexAttribDivisor;
-  PFNGLVERTEXATTRIBP1UI_PROC* glVertexAttribP1ui;
-  PFNGLVERTEXATTRIBP1UIV_PROC* glVertexAttribP1uiv;
-  PFNGLVERTEXATTRIBP2UI_PROC* glVertexAttribP2ui;
-  PFNGLVERTEXATTRIBP2UIV_PROC* glVertexAttribP2uiv;
-  PFNGLVERTEXATTRIBP3UI_PROC* glVertexAttribP3ui;
-  PFNGLVERTEXATTRIBP3UIV_PROC* glVertexAttribP3uiv;
-  PFNGLVERTEXATTRIBP4UI_PROC* glVertexAttribP4ui;
-  PFNGLVERTEXATTRIBP4UIV_PROC* glVertexAttribP4uiv;
-*/
 };
 
 typedef struct OpenGLBindings OpenGLBindings;
@@ -1642,20 +1447,13 @@ typedef struct OpenGLBindings OpenGLBindings;
 #define GL_VERSION_2_1
 #define GL_VERSION_3_0
 #define GL_VERSION_3_1
-#define GL_VERSION_3_2
-#define GL_VERSION_3_3
 
 /* ---------------------- Flags for optional extensions ---------------------- */
 
-
-
-struct GLFWwindow;
-typedef struct GLFWwindow GLFWwindow;
-
-int flextInit(GLFWwindow* window, OpenGLBindings *bindings);
+void flextInit(OpenGLBindings *bindings);
 
 #define FLEXT_MAJOR_VERSION 3
-#define FLEXT_MINOR_VERSION 3
+#define FLEXT_MINOR_VERSION 1
 #define FLEXT_CORE_PROFILE 1
 
 #ifdef __cplusplus

--- a/examples/protonect/src/flextGL.h
+++ b/examples/protonect/src/flextGL.h
@@ -841,7 +841,7 @@ typedef struct __GLsync *GLsync;
 #define GL_INVALID_INDEX 0xFFFFFFFFu
 
 /* GL_VERSION_3_2 */
-
+/*
 #define GL_CONTEXT_CORE_PROFILE_BIT 0x00000001
 #define GL_CONTEXT_COMPATIBILITY_PROFILE_BIT 0x00000002
 #define GL_LINES_ADJACENCY 0x000A
@@ -906,9 +906,9 @@ typedef struct __GLsync *GLsync;
 #define GL_MAX_COLOR_TEXTURE_SAMPLES 0x910E
 #define GL_MAX_DEPTH_TEXTURE_SAMPLES 0x910F
 #define GL_MAX_INTEGER_SAMPLES 0x9110
-
+*/
 /* GL_VERSION_3_3 */
-
+/*
 #define GL_VERTEX_ATTRIB_ARRAY_DIVISOR 0x88FE
 #define GL_SRC1_COLOR 0x88F9
 #define GL_ONE_MINUS_SRC1_COLOR 0x88FA
@@ -925,7 +925,7 @@ typedef struct __GLsync *GLsync;
 #define GL_TIME_ELAPSED 0x88BF
 #define GL_TIMESTAMP 0x8E28
 #define GL_INT_2_10_10_10_REV 0x8D9F
-
+*/
 /* --------------------------- FUNCTION PROTOTYPES --------------------------- */
 
     
@@ -1258,7 +1258,7 @@ typedef void (APIENTRY PFNGLGETACTIVEUNIFORMBLOCKNAME_PROC (GLuint program, GLui
 typedef void (APIENTRY PFNGLUNIFORMBLOCKBINDING_PROC (GLuint program, GLuint uniformBlockIndex, GLuint uniformBlockBinding));
     
 /* GL_VERSION_3_2 */
-  
+/*
 typedef void (APIENTRY PFNGLDRAWELEMENTSBASEVERTEX_PROC (GLenum mode, GLsizei count, GLenum type, const void * indices, GLint basevertex));
 typedef void (APIENTRY PFNGLDRAWRANGEELEMENTSBASEVERTEX_PROC (GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, const void * indices, GLint basevertex));
 typedef void (APIENTRY PFNGLDRAWELEMENTSINSTANCEDBASEVERTEX_PROC (GLenum mode, GLsizei count, GLenum type, const void * indices, GLsizei instancecount, GLint basevertex));
@@ -1278,9 +1278,9 @@ typedef void (APIENTRY PFNGLTEXIMAGE2DMULTISAMPLE_PROC (GLenum target, GLsizei s
 typedef void (APIENTRY PFNGLTEXIMAGE3DMULTISAMPLE_PROC (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLboolean fixedsamplelocations));
 typedef void (APIENTRY PFNGLGETMULTISAMPLEFV_PROC (GLenum pname, GLuint index, GLfloat * val));
 typedef void (APIENTRY PFNGLSAMPLEMASKI_PROC (GLuint maskNumber, GLbitfield mask));
-    
+*/
 /* GL_VERSION_3_3 */
-  
+/*
 typedef void (APIENTRY PFNGLBINDFRAGDATALOCATIONINDEXED_PROC (GLuint program, GLuint colorNumber, GLuint index, const GLchar * name));
 typedef GLint (APIENTRY PFNGLGETFRAGDATAINDEX_PROC (GLuint program, const GLchar * name));
 typedef void (APIENTRY PFNGLGENSAMPLERS_PROC (GLsizei count, GLuint * samplers));
@@ -1309,7 +1309,7 @@ typedef void (APIENTRY PFNGLVERTEXATTRIBP3UI_PROC (GLuint index, GLenum type, GL
 typedef void (APIENTRY PFNGLVERTEXATTRIBP3UIV_PROC (GLuint index, GLenum type, GLboolean normalized, const GLuint * value));
 typedef void (APIENTRY PFNGLVERTEXATTRIBP4UI_PROC (GLuint index, GLenum type, GLboolean normalized, GLuint value));
 typedef void (APIENTRY PFNGLVERTEXATTRIBP4UIV_PROC (GLuint index, GLenum type, GLboolean normalized, const GLuint * value));
-        
+*/
 struct OpenGLBindings
 {
     
@@ -1574,7 +1574,7 @@ struct OpenGLBindings
   PFNGLUNIFORMBLOCKBINDING_PROC* glUniformBlockBinding;
     
   /* GL_VERSION_3_2 */
-
+/*
   PFNGLDRAWELEMENTSBASEVERTEX_PROC* glDrawElementsBaseVertex;
   PFNGLDRAWRANGEELEMENTSBASEVERTEX_PROC* glDrawRangeElementsBaseVertex;
   PFNGLDRAWELEMENTSINSTANCEDBASEVERTEX_PROC* glDrawElementsInstancedBaseVertex;
@@ -1594,9 +1594,9 @@ struct OpenGLBindings
   PFNGLTEXIMAGE3DMULTISAMPLE_PROC* glTexImage3DMultisample;
   PFNGLGETMULTISAMPLEFV_PROC* glGetMultisamplefv;
   PFNGLSAMPLEMASKI_PROC* glSampleMaski;
-    
+*/
   /* GL_VERSION_3_3 */
-
+/*
   PFNGLBINDFRAGDATALOCATIONINDEXED_PROC* glBindFragDataLocationIndexed;
   PFNGLGETFRAGDATAINDEX_PROC* glGetFragDataIndex;
   PFNGLGENSAMPLERS_PROC* glGenSamplers;
@@ -1625,6 +1625,7 @@ struct OpenGLBindings
   PFNGLVERTEXATTRIBP3UIV_PROC* glVertexAttribP3uiv;
   PFNGLVERTEXATTRIBP4UI_PROC* glVertexAttribP4ui;
   PFNGLVERTEXATTRIBP4UIV_PROC* glVertexAttribP4uiv;
+*/
 };
 
 typedef struct OpenGLBindings OpenGLBindings;

--- a/examples/protonect/src/opengl_depth_packet_processor.cpp
+++ b/examples/protonect/src/opengl_depth_packet_processor.cpp
@@ -32,7 +32,8 @@
 #include <GLFW/glfw3.h>
 
 #include <fstream>
-
+#include <string>
+#include <map>
 
 #include <stdint.h>
 
@@ -117,6 +118,8 @@ bool loadBufferFromFile(const std::string& filename, unsigned char *buffer, size
 
 struct ShaderProgram : public WithOpenGLBindings
 {
+  typedef std::map<std::string, int> FragDataMap;
+  FragDataMap frag_data_map_;
   GLuint program, vertex_shader, fragment_shader;
 
   char error_buffer[2048];
@@ -142,6 +145,11 @@ struct ShaderProgram : public WithOpenGLBindings
     int length_ = src.length();
     fragment_shader = gl()->glCreateShader(GL_FRAGMENT_SHADER);
     gl()->glShaderSource(fragment_shader, 1, &src_, &length_);
+  }
+
+  void bindFragDataLocation(const std::string &name, int output)
+  {
+    frag_data_map_[name] = output;
   }
 
   void build()
@@ -171,6 +179,11 @@ struct ShaderProgram : public WithOpenGLBindings
     program = gl()->glCreateProgram();
     gl()->glAttachShader(program, vertex_shader);
     gl()->glAttachShader(program, fragment_shader);
+
+    for(FragDataMap::iterator it = frag_data_map_.begin(); it != frag_data_map_.end(); ++it)
+    {
+      gl()->glBindFragDataLocation(program, it->second, it->first.c_str());
+    }
 
     gl()->glLinkProgram(program);
 
@@ -469,24 +482,39 @@ struct OpenGLDepthPacketProcessorImpl : public WithOpenGLBindings, public WithPe
 
     stage1.setVertexShader(loadShaderSource(shader_folder + "default.vs"));
     stage1.setFragmentShader(loadShaderSource(shader_folder + "stage1.fs"));
+    stage1.bindFragDataLocation("Debug", 0);
+    stage1.bindFragDataLocation("A", 1);
+    stage1.bindFragDataLocation("B", 2);
+    stage1.bindFragDataLocation("Norm", 3);
+    stage1.bindFragDataLocation("Infrared", 4);
     stage1.build();
 
     filter1.setVertexShader(loadShaderSource(shader_folder + "default.vs"));
     filter1.setFragmentShader(loadShaderSource(shader_folder + "filter1.fs"));
+    filter1.bindFragDataLocation("Debug", 0);
+    filter1.bindFragDataLocation("FilterA", 1);
+    filter1.bindFragDataLocation("FilterB", 2);
+    filter1.bindFragDataLocation("MaxEdgeTest", 3);
     filter1.build();
 
     stage2.setVertexShader(loadShaderSource(shader_folder + "default.vs"));
     stage2.setFragmentShader(loadShaderSource(shader_folder + "stage2.fs"));
+    stage2.bindFragDataLocation("Debug", 0);
+    stage2.bindFragDataLocation("Depth", 1);
+    stage2.bindFragDataLocation("DepthAndIrSum", 2);
     stage2.build();
 
     filter2.setVertexShader(loadShaderSource(shader_folder + "default.vs"));
     filter2.setFragmentShader(loadShaderSource(shader_folder + "filter2.fs"));
+    filter2.bindFragDataLocation("Debug", 0);
+    filter2.bindFragDataLocation("FilterDepth", 1);
     filter2.build();
 
     if(do_debug)
     {
       debug.setVertexShader(loadShaderSource(shader_folder + "default.vs"));
       debug.setFragmentShader(loadShaderSource(shader_folder + "debug.fs"));
+      debug.bindFragDataLocation("Debug", 0);
       debug.build();
     }
 
@@ -545,11 +573,11 @@ struct OpenGLDepthPacketProcessorImpl : public WithOpenGLBindings, public WithPe
     gl()->glBindBuffer(GL_ARRAY_BUFFER, square_vbo);
     gl()->glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
 
-    GLint position_attr = stage1.getAttributeLocation("Position");
+    GLint position_attr = stage1.getAttributeLocation("InputPosition");
     gl()->glVertexAttribPointer(position_attr, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (GLvoid*)0);
     gl()->glEnableVertexAttribArray(position_attr);
 
-    GLint texcoord_attr = stage1.getAttributeLocation("TexCoord");
+    GLint texcoord_attr = stage1.getAttributeLocation("InputTexCoord");
     gl()->glVertexAttribPointer(texcoord_attr, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (GLvoid*)(2 * sizeof(float)));
     gl()->glEnableVertexAttribArray(texcoord_attr);
   }
@@ -751,11 +779,11 @@ OpenGLDepthPacketProcessor::OpenGLDepthPacketProcessor(void *parent_opengl_conte
   // setup context
   glfwDefaultWindowHints();
   glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
   #ifdef __APPLE__
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
   #endif
-  glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+  glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_ANY_PROFILE);
   glfwWindowHint(GLFW_VISIBLE, debug ? GL_TRUE : GL_FALSE);
 
   GLFWwindow* window = glfwCreateWindow(1024, 848, "OpenGLDepthPacketProcessor", 0, parent_window);

--- a/examples/protonect/src/opengl_depth_packet_processor.cpp
+++ b/examples/protonect/src/opengl_depth_packet_processor.cpp
@@ -519,12 +519,18 @@ struct OpenGLDepthPacketProcessorImpl : public WithOpenGLBindings, public WithPe
   {
     ChangeCurrentOpenGLContext ctx(opengl_context_ptr);
     
-    OpenGLBindings *b = new OpenGLBindings();
-    if (flextInit(opengl_context_ptr, b) == 0)
-    {
-        LOG_ERROR << "Failed to initialize flextGL.";
+    int major = glfwGetWindowAttrib(opengl_context_ptr, GLFW_CONTEXT_VERSION_MAJOR);
+    int minor = glfwGetWindowAttrib(opengl_context_ptr, GLFW_CONTEXT_VERSION_MINOR);
+
+    if (major * 10 + minor < 31) {
+        LOG_ERROR << "OpenGL version 3.1 not supported.";
+        LOG_ERROR << "Your version is " << major << "." << minor;
+        LOG_ERROR << "Try updating your graphics driver.";
         exit(-1);
     }
+
+    OpenGLBindings *b = new OpenGLBindings();
+    flextInit(b);
     gl(b);
 
     input_data.allocate(352, 424 * 9);

--- a/examples/protonect/src/opengl_depth_packet_processor.cpp
+++ b/examples/protonect/src/opengl_depth_packet_processor.cpp
@@ -365,10 +365,10 @@ struct OpenGLDepthPacketProcessorImpl : public WithOpenGLBindings, public WithPe
   Texture<U16C1> input_data;
 
   Texture<F32C4> stage1_debug;
-  Texture<F32C3> stage1_data[3];
+  Texture<F32C4> stage1_data[3];
   Texture<F32C1> stage1_infrared;
 
-  Texture<F32C3> filter1_data[2];
+  Texture<F32C4> filter1_data[2];
   Texture<U8C1> filter1_max_edge_test;
   Texture<F32C4> filter1_debug;
 
@@ -455,6 +455,16 @@ struct OpenGLDepthPacketProcessorImpl : public WithOpenGLBindings, public WithPe
     debug.gl(b);
   }
 
+  void checkFBO(GLenum target)
+  {
+    GLenum status = gl()->glCheckFramebufferStatus(target);
+    if (status != GL_FRAMEBUFFER_COMPLETE)
+    {
+      LOG_ERROR << "incomplete FBO " << status;
+      exit(-1);
+    }
+  }
+
   void initialize()
   {
     ChangeCurrentOpenGLContext ctx(opengl_context_ptr);
@@ -539,6 +549,7 @@ struct OpenGLDepthPacketProcessorImpl : public WithOpenGLBindings, public WithPe
     gl()->glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT2, GL_TEXTURE_RECTANGLE, stage1_data[1].texture, 0);
     gl()->glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT3, GL_TEXTURE_RECTANGLE, stage1_data[2].texture, 0);
     gl()->glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT4, GL_TEXTURE_RECTANGLE, stage1_infrared.texture, 0);
+    checkFBO(GL_DRAW_FRAMEBUFFER);
 
     gl()->glGenFramebuffers(1, &filter1_framebuffer);
     gl()->glBindFramebuffer(GL_DRAW_FRAMEBUFFER, filter1_framebuffer);
@@ -550,6 +561,7 @@ struct OpenGLDepthPacketProcessorImpl : public WithOpenGLBindings, public WithPe
     gl()->glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_RECTANGLE, filter1_data[0].texture, 0);
     gl()->glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT2, GL_TEXTURE_RECTANGLE, filter1_data[1].texture, 0);
     gl()->glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT3, GL_TEXTURE_RECTANGLE, filter1_max_edge_test.texture, 0);
+    checkFBO(GL_DRAW_FRAMEBUFFER);
 
     gl()->glGenFramebuffers(1, &stage2_framebuffer);
     gl()->glBindFramebuffer(GL_DRAW_FRAMEBUFFER, stage2_framebuffer);
@@ -560,6 +572,7 @@ struct OpenGLDepthPacketProcessorImpl : public WithOpenGLBindings, public WithPe
     if(do_debug) gl()->glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_RECTANGLE, stage2_debug.texture, 0);
     gl()->glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_RECTANGLE, stage2_depth.texture, 0);
     gl()->glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT2, GL_TEXTURE_RECTANGLE, stage2_depth_and_ir_sum.texture, 0);
+    checkFBO(GL_DRAW_FRAMEBUFFER);
 
     gl()->glGenFramebuffers(1, &filter2_framebuffer);
     gl()->glBindFramebuffer(GL_DRAW_FRAMEBUFFER, filter2_framebuffer);
@@ -569,6 +582,7 @@ struct OpenGLDepthPacketProcessorImpl : public WithOpenGLBindings, public WithPe
 
     if(do_debug) gl()->glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_RECTANGLE, filter2_debug.texture, 0);
     gl()->glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_RECTANGLE, filter2_depth.texture, 0);
+    checkFBO(GL_DRAW_FRAMEBUFFER);
 
     Vertex bl = {-1.0f, -1.0f, 0.0f, 0.0f }, br = { 1.0f, -1.0f, 512.0f, 0.0f }, tl = {-1.0f, 1.0f, 0.0f, 424.0f }, tr = { 1.0f, 1.0f, 512.0f, 424.0f };
     Vertex vertices[] = {

--- a/examples/protonect/src/opengl_depth_packet_processor.cpp
+++ b/examples/protonect/src/opengl_depth_packet_processor.cpp
@@ -279,6 +279,14 @@ public:
 
   void allocate(size_t new_width, size_t new_height)
   {
+    GLint max_size;
+    glGetIntegerv(GL_MAX_RECTANGLE_TEXTURE_SIZE, &max_size);
+    if (new_width > max_size || new_height > max_size)
+    {
+      LOG_ERROR << "GL_MAX_RECTANGLE_TEXTURE_SIZE is too small: " << max_size;
+      exit(-1);
+    }
+
     width = new_width;
     height = new_height;
     size = height * width * bytes_per_pixel;
@@ -459,7 +467,7 @@ struct OpenGLDepthPacketProcessorImpl : public WithOpenGLBindings, public WithPe
     }
     gl(b);
 
-    input_data.allocate(352, 424 * 10);
+    input_data.allocate(352, 424 * 9);
 
     for(int i = 0; i < 3; ++i)
       stage1_data[i].allocate(512, 424);
@@ -942,7 +950,7 @@ void OpenGLDepthPacketProcessor::process(const DepthPacket &packet)
 
   glfwMakeContextCurrent(impl_->opengl_context_ptr);
 
-  std::copy(packet.buffer, packet.buffer + packet.buffer_length, impl_->input_data.data);
+  std::copy(packet.buffer, packet.buffer + packet.buffer_length/10*9, impl_->input_data.data);
   impl_->input_data.upload();
   impl_->run(has_listener ? &ir : 0, has_listener ? &depth : 0);
 

--- a/examples/protonect/src/shader/debug.fs
+++ b/examples/protonect/src/shader/debug.fs
@@ -1,16 +1,14 @@
-#version 330
+#version 140
 
 uniform sampler2DRect Data;
 
-in VertexData {
-    vec2 TexCoord;
-} FragmentIn;
+in vec2 TexCoord;
 
-layout(location = 0) out vec4 Color;
+out vec4 Color;
 
 void main(void)
 {
-  ivec2 uv = ivec2(FragmentIn.TexCoord.x, FragmentIn.TexCoord.y);
+  ivec2 uv = ivec2(TexCoord.x, TexCoord.y);
   
   Color = texelFetch(Data, uv);
 }

--- a/examples/protonect/src/shader/debug.fs
+++ b/examples/protonect/src/shader/debug.fs
@@ -1,5 +1,3 @@
-#version 140
-
 uniform sampler2DRect Data;
 
 in vec2 TexCoord;

--- a/examples/protonect/src/shader/default.vs
+++ b/examples/protonect/src/shader/default.vs
@@ -1,14 +1,12 @@
-#version 330
+#version 140
 
-in vec2 Position;
-in vec2 TexCoord;
+in vec2 InputPosition;
+in vec2 InputTexCoord;
 
-out VertexData {
-  vec2 TexCoord;
-} VertexOut;
+out vec2 TexCoord;
 
 void main(void)
 {
-  gl_Position = vec4(Position, 0.0, 1.0);
-  VertexOut.TexCoord = TexCoord;
+  gl_Position = vec4(InputPosition, 0.0, 1.0);
+  TexCoord = InputTexCoord;
 }

--- a/examples/protonect/src/shader/default.vs
+++ b/examples/protonect/src/shader/default.vs
@@ -1,5 +1,3 @@
-#version 140
-
 in vec2 InputPosition;
 in vec2 InputTexCoord;
 

--- a/examples/protonect/src/shader/filter1.fs
+++ b/examples/protonect/src/shader/filter1.fs
@@ -1,4 +1,4 @@
-#version 330
+#version 140
 
 struct Parameters
 {
@@ -40,14 +40,12 @@ uniform sampler2DRect Norm;
 
 uniform Parameters Params;
 
-in VertexData {
-    vec2 TexCoord;
-} FragmentIn;
+in vec2 TexCoord;
 
-layout(location = 0) out vec4 Debug;
-layout(location = 1) out vec3 FilterA;
-layout(location = 2) out vec3 FilterB;
-layout(location = 3) out uint MaxEdgeTest;
+/*layout(location = 0)*/ out vec4 Debug;
+/*layout(location = 1)*/ out vec3 FilterA;
+/*layout(location = 2)*/ out vec3 FilterB;
+/*layout(location = 3)*/ out uint MaxEdgeTest;
 
 void applyBilateralFilter(ivec2 uv)
 {
@@ -115,7 +113,7 @@ void applyBilateralFilter(ivec2 uv)
 
 void main(void)
 {
-  ivec2 uv = ivec2(FragmentIn.TexCoord.x, FragmentIn.TexCoord.y);
+  ivec2 uv = ivec2(TexCoord.x, TexCoord.y);
     
   applyBilateralFilter(uv);
   

--- a/examples/protonect/src/shader/filter1.fs
+++ b/examples/protonect/src/shader/filter1.fs
@@ -1,5 +1,3 @@
-#version 140
-
 struct Parameters
 {
   float ab_multiplier;

--- a/examples/protonect/src/shader/filter2.fs
+++ b/examples/protonect/src/shader/filter2.fs
@@ -1,4 +1,4 @@
-#version 330
+#version 140
 
 struct Parameters
 {
@@ -39,12 +39,10 @@ uniform usampler2DRect MaxEdgeTest;
 
 uniform Parameters Params;
 
-in VertexData {
-    vec2 TexCoord;
-} FragmentIn;
+in vec2 TexCoord;
 
-layout(location = 0) out vec4 Debug;
-layout(location = 1) out float FilterDepth;
+/*layout(location = 0)*/ out vec4 Debug;
+/*layout(location = 1)*/ out float FilterDepth;
 
 void applyEdgeAwareFilter(ivec2 uv)
 {
@@ -126,7 +124,7 @@ void applyEdgeAwareFilter(ivec2 uv)
 
 void main(void)
 {
-  ivec2 uv = ivec2(FragmentIn.TexCoord.x, FragmentIn.TexCoord.y);
+  ivec2 uv = ivec2(TexCoord.x, TexCoord.y);
   
   applyEdgeAwareFilter(uv);
   

--- a/examples/protonect/src/shader/filter2.fs
+++ b/examples/protonect/src/shader/filter2.fs
@@ -1,5 +1,3 @@
-#version 140
-
 struct Parameters
 {
   float ab_multiplier;

--- a/examples/protonect/src/shader/stage1.fs
+++ b/examples/protonect/src/shader/stage1.fs
@@ -1,5 +1,3 @@
-#version 140
-
 struct Parameters
 {
   float ab_multiplier;
@@ -104,6 +102,9 @@ void main(void)
   vec2 ab1 = processMeasurementTriple(uv, P0Table1, 3, Params.ab_multiplier_per_frq.y, saturated.y);
   vec2 ab2 = processMeasurementTriple(uv, P0Table2, 6, Params.ab_multiplier_per_frq.z, saturated.z);
   
+#ifdef MESA_BUGGY_BOOL_CMP
+  valid_pixel = valid_pixel ? true : false;
+#endif
   bvec3 invalid_pixel = bvec3(!valid_pixel);
   
   A    = mix(vec3(ab0.x, ab1.x, ab2.x), vec3(0.0), invalid_pixel);

--- a/examples/protonect/src/shader/stage1.fs
+++ b/examples/protonect/src/shader/stage1.fs
@@ -1,4 +1,4 @@
-#version 330
+#version 140
 
 struct Parameters
 {
@@ -43,16 +43,14 @@ uniform sampler2DRect ZTable;
 
 uniform Parameters Params;
 
-in VertexData {
-    vec2 TexCoord;
-} FragmentIn;
+in vec2 TexCoord;
 
-layout(location = 0) out vec4 Debug;
-
-layout(location = 1) out vec3 A;
-layout(location = 2) out vec3 B;
-layout(location = 3) out vec3 Norm;
-layout(location = 4) out float Infrared;
+/*layout(location = 0)*/ out vec4 Debug;
+/*                    */
+/*layout(location = 1)*/ out vec3 A;
+/*layout(location = 2)*/ out vec3 B;
+/*layout(location = 3)*/ out vec3 Norm;
+/*layout(location = 4)*/ out float Infrared;
 
 #define M_PI 3.1415926535897932384626433832795
 
@@ -97,7 +95,7 @@ vec2 processMeasurementTriple(in ivec2 uv, in usampler2DRect p0table, in int off
 
 void main(void)
 {
-  ivec2 uv = ivec2(FragmentIn.TexCoord.x, FragmentIn.TexCoord.y);
+  ivec2 uv = ivec2(TexCoord.x, TexCoord.y);
     
   bool valid_pixel = 0.0 < texelFetch(ZTable, uv).x;
   bvec3 saturated = bvec3(valid_pixel);

--- a/examples/protonect/src/shader/stage2.fs
+++ b/examples/protonect/src/shader/stage2.fs
@@ -1,4 +1,4 @@
-#version 330
+#version 140
 
 struct Parameters
 {
@@ -41,19 +41,17 @@ uniform sampler2DRect ZTable;
 
 uniform Parameters Params;
 
-in VertexData {
-    vec2 TexCoord;
-} FragmentIn;
+in vec2 TexCoord;
 
-layout(location = 0) out vec4 Debug;
-layout(location = 1) out float Depth;
-layout(location = 2) out vec2 DepthAndIrSum;
+/*layout(location = 0)*/ out vec4 Debug;
+/*layout(location = 1)*/ out float Depth;
+/*layout(location = 2)*/ out vec2 DepthAndIrSum;
 
 #define M_PI 3.1415926535897932384626433832795
 
 void main(void)
 {
-  ivec2 uv = ivec2(FragmentIn.TexCoord.x, FragmentIn.TexCoord.y);
+  ivec2 uv = ivec2(TexCoord.x, TexCoord.y);
       
   vec3 a = texelFetch(A, uv).xyz;
   vec3 b = texelFetch(B, uv).xyz;

--- a/examples/protonect/src/shader/stage2.fs
+++ b/examples/protonect/src/shader/stage2.fs
@@ -1,5 +1,3 @@
-#version 140
-
 struct Parameters
 {
   float ab_multiplier;

--- a/examples/protonect/src/usb_control.cpp
+++ b/examples/protonect/src/usb_control.cpp
@@ -188,7 +188,7 @@ UsbControl::~UsbControl()
 }
 
 #define CHECK_LIBUSB_RESULT(__CODE, __RESULT) if((__CODE = (__RESULT == LIBUSB_SUCCESS ? Success : Error)) == Error) LOG_ERROR
-#define WRITE_LIBUSB_ERROR(__RESULT) "libusb error " << __RESULT << ": " << libusb_error_name(__RESULT)
+#define WRITE_LIBUSB_ERROR(__RESULT) libusb_error_name(__RESULT) << " " << libusb_strerror((libusb_error)__RESULT) << ". Try debugging with environment variable: export LIBUSB_DEBUG=4 ."
 
 UsbControl::ResultCode UsbControl::setConfiguration()
 {

--- a/examples/protonect/viewer.cpp
+++ b/examples/protonect/viewer.cpp
@@ -22,7 +22,7 @@ void Viewer::initialize()
     window = glfwCreateWindow(1280, 800, "Viewer", 0, NULL);
     glfwMakeContextCurrent(window);
     OpenGLBindings *b = new OpenGLBindings();
-    flextInit(window, b);
+    flextInit(b);
     gl(b);
 
     std::string vertexshadersrc = ""


### PR DESCRIPTION
This is rebased on #364. Commits of this PR begin from "changed minimal opengl version to 3.1".

This PR fixes all bugs on Intel GPU. This PR supersedes #352.

Performance comparison on i7-4600U @ 2.10GHz:

```
[Info] [OpenGLDepthPacketProcessor] avg. time: 21.3259ms -> ~46.8913Hz
[Info] [OpenCLDepthPacketProcessor] avg. time: 16.9965ms -> ~58.8356Hz
```