### PR TITLE
Fix class LogMessage link error in windows and compile error

### DIFF
--- a/examples/protonect/CMakeLists.txt
+++ b/examples/protonect/CMakeLists.txt
@@ -70,6 +70,9 @@ SET(SOURCES
   include/libfreenect2/usb/event_loop.h
   include/libfreenect2/usb/transfer_pool.h
 
+  include/libfreenect2/usb/logger.h
+  include/libfreenect2/usb/logging.h
+
   include/libfreenect2/async_packet_processor.h  
   include/libfreenect2/depth_packet_processor.h
   include/libfreenect2/depth_packet_stream_parser.h

--- a/examples/protonect/include/libfreenect2/logging.h
+++ b/examples/protonect/include/libfreenect2/logging.h
@@ -49,7 +49,7 @@ private:
   WithPerfLoggingImpl *impl_;
 };
 
-class LogMessage
+class LIBFREENECT2_API LogMessage
 {
 private:
   Logger *logger_;
@@ -62,7 +62,7 @@ public:
   std::ostream &stream();
 };
 
-std::string getShortName(const char *func);
+LIBFREENECT2_API std::string getShortName(const char *func);
 
 } /* namespace libfreenect2 */
 

--- a/examples/protonect/src/logging.cpp
+++ b/examples/protonect/src/logging.cpp
@@ -247,7 +247,7 @@ void WithPerfLogging::startTiming()
 
 std::ostream &WithPerfLogging::stopTiming(std::ostream &stream)
 {
-  impl_->stop(stream);
+  return impl_->stop(stream);
 }
 
 std::string getShortName(const char *func)


### PR DESCRIPTION
* Adding logger.h and loggng.h head file's declaration to CMakeLists.txt.
* Adding DLL declaration for  class LogMessage and getShortName function to fix link error in windows.
* Adding return key word to logging.cpp's stopTiming function to fix compile error
