### PR TITLE
Fix class LogMessage link error in windows and compile error

### DIFF
--- a/examples/protonect/CMakeLists.txt
+++ b/examples/protonect/CMakeLists.txt
@@ -70,6 +70,9 @@ SET(SOURCES
   include/libfreenect2/usb/event_loop.h
   include/libfreenect2/usb/transfer_pool.h
 
+  include/libfreenect2/usb/logger.h
+  include/libfreenect2/usb/logging.h
+
   include/libfreenect2/async_packet_processor.h  
   include/libfreenect2/depth_packet_processor.h
   include/libfreenect2/depth_packet_stream_parser.h

--- a/examples/protonect/CMakeLists.txt
+++ b/examples/protonect/CMakeLists.txt
@@ -70,8 +70,8 @@ SET(SOURCES
   include/libfreenect2/usb/event_loop.h
   include/libfreenect2/usb/transfer_pool.h
 
-  include/libfreenect2/usb/logger.h
-  include/libfreenect2/usb/logging.h
+  include/libfreenect2/logger.h
+  include/libfreenect2/logging.h
 
   include/libfreenect2/async_packet_processor.h  
   include/libfreenect2/depth_packet_processor.h

--- a/examples/protonect/include/libfreenect2/logging.h
+++ b/examples/protonect/include/libfreenect2/logging.h
@@ -49,7 +49,7 @@ private:
   WithPerfLoggingImpl *impl_;
 };
 
-class LogMessage
+class LIBFREENECT2_API LogMessage
 {
 private:
   Logger *logger_;
@@ -62,7 +62,7 @@ public:
   std::ostream &stream();
 };
 
-std::string getShortName(const char *func);
+LIBFREENECT2_API std::string getShortName(const char *func);
 
 } /* namespace libfreenect2 */
 

--- a/examples/protonect/src/cpu_depth_packet_processor.cpp
+++ b/examples/protonect/src/cpu_depth_packet_processor.cpp
@@ -77,7 +77,9 @@ private:
   {
     if(owns_buffer && buffer_ != 0)
     {
-      delete[] buffer_;
+      if (buffer_ != 0){
+        delete[] buffer_;
+      }
       owns_buffer = false;
       buffer_ = 0;
       buffer_end_ = 0;
@@ -85,7 +87,7 @@ private:
   }
 
 public:
-  Mat()
+  Mat():buffer_(0), buffer_end_(0)
   {
   }
 
@@ -938,17 +940,20 @@ void CpuDepthPacketProcessor::process(const DepthPacket &packet)
       }
   }
 
-  if(listener_->onNewFrame(Frame::Ir, impl_->ir_frame))
-  {
-    impl_->newIrFrame();
-  }
-
-  if(listener_->onNewFrame(Frame::Depth, impl_->depth_frame))
-  {
-    impl_->newDepthFrame();
-  }
-
   impl_->stopTiming(LOG_INFO);
+
+  if (listener_ != 0 ){
+    if(listener_->onNewFrame(Frame::Ir, impl_->ir_frame))
+    {
+      impl_->newIrFrame();
+    }
+
+    if(listener_->onNewFrame(Frame::Depth, impl_->depth_frame))
+    {
+      impl_->newDepthFrame();
+    }
+  }
+
 }
 
 } /* namespace libfreenect2 */

--- a/examples/protonect/src/cpu_depth_packet_processor.cpp
+++ b/examples/protonect/src/cpu_depth_packet_processor.cpp
@@ -77,9 +77,7 @@ private:
   {
     if(owns_buffer && buffer_ != 0)
     {
-      if (buffer_ != 0){
-        delete[] buffer_;
-      }
+      delete[] buffer_;
       owns_buffer = false;
       buffer_ = 0;
       buffer_end_ = 0;

--- a/examples/protonect/src/logging.cpp
+++ b/examples/protonect/src/logging.cpp
@@ -247,7 +247,7 @@ void WithPerfLogging::startTiming()
 
 std::ostream &WithPerfLogging::stopTiming(std::ostream &stream)
 {
-  impl_->stop(stream);
+  return impl_->stop(stream);
 }
 
 std::string getShortName(const char *func)


### PR DESCRIPTION
* Fix class LogMessage link error  in windows 
* Fix logging.cpp's compiling error
* When exit libfreenect2::CpuDepthPacketProcessor::process is called but listener_ pointer is NULL. Adding checking to listener_
* First time deleting not alloced memmory pointer buffer_ will fail.When create Mat buffer_ set NULL