### PR TITLE
fixes missing std::string include in libfreenect2.hpp

### DIFF
--- a/include/libfreenect2/libfreenect2.hpp
+++ b/include/libfreenect2/libfreenect2.hpp
@@ -31,6 +31,7 @@
 
 #include <libfreenect2/config.h>
 #include <libfreenect2/frame_listener.hpp>
+#include <string>
 
 namespace libfreenect2
 {


### PR DESCRIPTION
fixes missing std::string include in libfreenect2.hpp