### PR TITLE
Protonect Window Fix

### DIFF
--- a/examples/viewer.h
+++ b/examples/viewer.h
@@ -271,6 +271,8 @@ private:
     std::map<std::string,libfreenect2::Frame*> frames;
     Texture<F8C4> rgb;
     Texture<F32C1> ir;
+    int win_height;
+    int win_width;
 public:
     Viewer();
     void initialize();
@@ -278,7 +280,9 @@ public:
     bool render();
     void addFrame(std::string id,libfreenect2::Frame* frame);
     void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods);
+    void winsize_callback(GLFWwindow* window, int w, int h);
     static void key_callbackstatic(GLFWwindow* window, int key, int scancode, int action, int mods);
+    static void winsize_callbackstatic(GLFWwindow* window, int w, int h);
 };
 
 #endif


### PR DESCRIPTION
On Mac, only the lower left quadrant was being rendered with the live frames. Also there was no dynamic handling of the window resizing. 

Tested only on Mac with retail Kinect v2 in 'cl' mode. Couldn't test in gl mode having the same problem as mentioned in issue #205 