### PR TITLE
quick README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ sudo dpkg -i libglfw3*_3.0.4-1_*.deb
 1. Build the actual protonect executable
 
     ```
+cd ..
 mkdir build && cd build
 cmake ..
 make


### PR DESCRIPTION
I'm guessing you want users to have build in the libfreenect/ directory instead of the libfreenect/depends/ directory. 