### PR TITLE
Forward ABI compatibility of Frame

### DIFF
--- a/include/libfreenect2/frame_listener.hpp
+++ b/include/libfreenect2/frame_listener.hpp
@@ -58,14 +58,24 @@ class LIBFREENECT2_API Frame
   float gain;             ///< Get the gain set by the color camera.
   float gamma;            ///< Get the gamma level set by the color camera.
 
-  Frame(size_t width, size_t height, size_t bytes_per_pixel) :
+  /** Construct a new frame.
+   * @param width Width in pixel
+   * @param height Height in pixel
+   * @param bytes_per_pixel Bytes per pixel
+   * @param data_ Memory to store frame data. If `NULL`, new memory is allocated.
+   */
+  Frame(size_t width, size_t height, size_t bytes_per_pixel, unsigned char *data_ = NULL) :
     width(width),
     height(height),
     bytes_per_pixel(bytes_per_pixel),
+    data(data_),
     exposure(0.f),
     gain(0.f),
-    gamma(0.f)
+    gamma(0.f),
+    rawdata(NULL)
   {
+    if (data_)
+      return;
     const size_t alignment = 64;
     size_t space = width * height * bytes_per_pixel + alignment;
     rawdata = new unsigned char[space];
@@ -74,7 +84,7 @@ class LIBFREENECT2_API Frame
     data = reinterpret_cast<unsigned char *>(aligned);
   }
 
-  ~Frame()
+  virtual ~Frame()
   {
     delete[] rawdata;
   }


### PR DESCRIPTION
`Frame` right now always allocates memory and there is no way to turn it off.

In the future, VT, VAAPI, and Tegra JPEG decoder, and CUDA processor all need to use custom memory allocators, and they will have to break ABI without this.

Example of how VT decoder changes it: https://github.com/OpenKinect/libfreenect2/pull/365/files#diff-7bd5995c21c16482ff1a19a27816180dL58