### PR TITLE
Fix MSVC FTBFS

### DIFF
--- a/include/internal/libfreenect2/depth_packet_processor.h
+++ b/include/internal/libfreenect2/depth_packet_processor.h
@@ -33,7 +33,6 @@
 #include <stdint.h>
 
 #include <libfreenect2/config.h>
-#define LIBFREENECT2_SETCONFIGURATION_COMPAT_INTERNAL
 #include <libfreenect2/libfreenect2.hpp>
 #include <libfreenect2/frame_listener.hpp>
 #include <libfreenect2/packet_processor.h>
@@ -53,7 +52,7 @@ struct DepthPacket
 /** Class for processing depth information. */
 typedef PacketProcessor<DepthPacket> BaseDepthPacketProcessor;
 
-class DepthPacketProcessor : public ConfigPacketProcessor, public BaseDepthPacketProcessor
+class DepthPacketProcessor : public BaseDepthPacketProcessor
 {
 public:
   typedef Freenect2Device::Config Config;

--- a/include/libfreenect2/libfreenect2.hpp
+++ b/include/libfreenect2/libfreenect2.hpp
@@ -365,19 +365,6 @@ public:
   virtual void close() = 0;
 };
 
-/** Deprecated method to configure packet processors
- * @deprecated Use Freenect2Device::setConfiguration() instead.
- *
- * Usage of `pipeline->getDepthPacketProcessor()->setConfiguration(config)`
- * should be converted to `device->setConfiguration(config)`
- */
-class ConfigPacketProcessor
-{
-public:
-  typedef Freenect2Device::Config Config;
-  LIBFREENECT2_DEPRECATED virtual void setConfiguration(const Config &config) = 0;
-};
-
 class Freenect2Impl;
 
 /**

--- a/include/libfreenect2/packet_pipeline.h
+++ b/include/libfreenect2/packet_pipeline.h
@@ -39,11 +39,6 @@ class RgbPacketProcessor;
 class DepthPacketProcessor;
 class PacketPipelineComponents;
 
-class ConfigPacketProcessor;
-#ifndef LIBFREENECT2_SETCONFIGURATION_COMPAT_INTERNAL
-#define DepthPacketProcessor ConfigPacketProcessor
-#endif
-
 /** @defgroup pipeline Packet Pipelines
  * Implement various methods to decode color and depth images with different performance and platform support
  *

--- a/src/libfreenect2.cpp
+++ b/src/libfreenect2.cpp
@@ -34,7 +34,6 @@
 #include <cmath>
 #define WRITE_LIBUSB_ERROR(__RESULT) libusb_error_name(__RESULT) << " " << libusb_strerror((libusb_error)__RESULT)
 
-#define LIBFREENECT2_SETCONFIGURATION_COMPAT_INTERNAL
 #include <libfreenect2/libfreenect2.hpp>
 
 #include <libfreenect2/usb/event_loop.h>

--- a/src/packet_pipeline.cpp
+++ b/src/packet_pipeline.cpp
@@ -26,7 +26,6 @@
 
 /** @file packet_pipeline.cpp Packet pipeline implementation. */
 
-#define LIBFREENECT2_SETCONFIGURATION_COMPAT_INTERNAL
 #include <libfreenect2/packet_pipeline.h>
 #include <libfreenect2/async_packet_processor.h>
 #include <libfreenect2/data_callback.h>


### PR DESCRIPTION
The workaround cdd4f06 (from #476) broke MSVC building (reported in #489). I didn't test MSVC in #476. MSVC refuses to resolve the symbol because the return type is different, which was the point of the workaround.

Alternative workarounds would make it more a mess. I have sent a patch to iai_kinect2 directly to use new API. https://github.com/code-iai/iai_kinect2/pull/189

Build tested OK with MSVC and GCC after this PR.