### PR TITLE
Fix Memory Leak in Viewer.cpp

### DIFF
--- a/examples/viewer.cpp
+++ b/examples/viewer.cpp
@@ -225,6 +225,9 @@ bool Viewer::render()
             glDrawArrays(GL_TRIANGLES, 0, 6);
             ir.deallocate();
         }
+
+        gl()->glDeleteBuffers(1, &triangle_vbo);
+        gl()->glDeleteVertexArrays(1, &triangle_vao);
     }
 
     // put the stuff we've been drawing onto the display


### PR DESCRIPTION
Deallocates VAO and VBO in viewer.cpp so that memory doesn't leak within the GL library.

Fixes https://github.com/OpenKinect/libfreenect2/issues/498