### PR TITLE
Preemptive API expansion

### DIFF
--- a/include/libfreenect2/frame_listener.hpp
+++ b/include/libfreenect2/frame_listener.hpp
@@ -44,7 +44,7 @@ namespace libfreenect2
 class LIBFREENECT2_API Frame
 {
   public:
-  /** Available types of frames and their pixel format. */
+  /** Available types of frames. */
   enum Type
   {
     Color = 1, ///< 1920x1080 32-bit BGRX.
@@ -52,15 +52,26 @@ class LIBFREENECT2_API Frame
     Depth = 4  ///< 512x424 float, unit: millimeter. Non-positive, NaN, and infinity are invalid or missing data.
   };
 
-  uint32_t timestamp;     ///< Unit: roughly or exactly 0.1 millisecond
-  uint32_t sequence;      ///< Increasing frame sequence number
+  /** (Proposed for 0.2) Pixel format. */
+  enum Format
+  {
+    BGRX,
+    RGBX,
+    Gray,
+    Float
+  };
+
   size_t width;           ///< Length of a line (in pixels).
   size_t height;          ///< Number of lines in the frame.
   size_t bytes_per_pixel; ///< Number of bytes in a pixel.
   unsigned char* data;    ///< Data of the frame (aligned). @see See Frame::Type for pixel format.
+  uint32_t timestamp;     ///< Unit: roughly or exactly 0.1 millisecond
+  uint32_t sequence;      ///< Increasing frame sequence number
   float exposure;         ///< From 0.5 (very bright) to ~60.0 (fully covered)
   float gain;             ///< From 1.0 (bright) to 1.5 (covered)
   float gamma;            ///< From 1.0 (bright) to 6.4 (covered)
+  uint32_t status;        ///< Reserved. To be defined in 0.2.
+  Format format;          ///< Reserved. To be defined in 0.2.
 
   /** Construct a new frame.
    * @param width Width in pixel

--- a/include/libfreenect2/libfreenect2.hpp
+++ b/include/libfreenect2/libfreenect2.hpp
@@ -355,14 +355,22 @@ public:
    * All above configuration must only be called before start() or after stop().
    *
    * FrameListener will receive frames when the device is running.
+   *
+   * @return Undefined. To be defined in 0.2.
    */
-  virtual void start() = 0;
+  virtual bool start() = 0;
 
-  /** Stop data processing. */
-  virtual void stop() = 0;
+  /** Stop data processing.
+   *
+   * @return Undefined. To be defined in 0.2.
+   */
+  virtual bool stop() = 0;
 
-  /** Shut down the device. */
-  virtual void close() = 0;
+  /** Shut down the device.
+   *
+   * @return Undefined. To be defined in 0.2.
+   */
+  virtual bool close() = 0;
 };
 
 class Freenect2Impl;

--- a/src/libfreenect2.cpp
+++ b/src/libfreenect2.cpp
@@ -259,9 +259,9 @@ public:
 
   virtual void setColorFrameListener(libfreenect2::FrameListener* rgb_frame_listener);
   virtual void setIrAndDepthFrameListener(libfreenect2::FrameListener* ir_frame_listener);
-  virtual void start();
-  virtual void stop();
-  virtual void close();
+  virtual bool start();
+  virtual bool stop();
+  virtual bool close();
 };
 
 struct PrintBusAndDevice
@@ -671,10 +671,10 @@ bool Freenect2DeviceImpl::open()
   return true;
 }
 
-void Freenect2DeviceImpl::start()
+bool Freenect2DeviceImpl::start()
 {
   LOG_INFO << "starting...";
-  if(state_ != Open) return;
+  if(state_ != Open) return false;
 
   CommandTransaction::Result serial_result, firmware_result, result;
 
@@ -790,16 +790,17 @@ void Freenect2DeviceImpl::start()
 
   state_ = Streaming;
   LOG_INFO << "started";
+  return true;
 }
 
-void Freenect2DeviceImpl::stop()
+bool Freenect2DeviceImpl::stop()
 {
   LOG_INFO << "stopping...";
 
   if(state_ != Streaming)
   {
     LOG_INFO << "already stopped, doing nothing";
-    return;
+    return false;
   }
 
   LOG_INFO << "disabling usb transfer submission...";
@@ -820,16 +821,17 @@ void Freenect2DeviceImpl::stop()
 
   state_ = Open;
   LOG_INFO << "stopped";
+  return true;
 }
 
-void Freenect2DeviceImpl::close()
+bool Freenect2DeviceImpl::close()
 {
   LOG_INFO << "closing...";
 
   if(state_ == Closed)
   {
     LOG_INFO << "already closed, doing nothing";
-    return;
+    return true;
   }
 
   if(state_ == Streaming)
@@ -863,6 +865,7 @@ void Freenect2DeviceImpl::close()
 
   state_ = Closed;
   LOG_INFO << "closed";
+  return true;
 }
 
 PacketPipeline *createDefaultPacketPipeline()


### PR DESCRIPTION
* Add return values to `Freenect2Device start(), stop(), close()` so device errors can be reported.
* Add a status field to `Frame` so processor errors can be reported. And a new `format` field. Also some minor tweaking in field ordering.

Though no actual error reporting is implemented. This only extends the API to preemptively avoid ABI breakage between 0.1 and 0.2.

This changes the current API though but most applications should be able to run without changes.

Tested with Debian, Ubuntu 14.04, Windows 8/MSVC2015, and tested with iai_kinect2.