### PR TITLE
Adding in CLI -help and -version options

### DIFF
--- a/examples/Protonect.cpp
+++ b/examples/Protonect.cpp
@@ -110,8 +110,9 @@ int main(int argc, char *argv[])
 /// [main]
 {
   std::string program_path(argv[0]);
+  std::cerr << "Version: " << LIBFREENECT2_VERSION << std::endl;
   std::cerr << "Environment variables: LOGFILE=<protonect.log>" << std::endl;
-  std::cerr << "Usage: " << program_path << " [gl | cl | cpu] [<device serial>] [-noviewer]" << std::endl;
+  std::cerr << "Usage: " << program_path << " [gl | cl | cpu] [<device serial>] [-noviewer] [-help] [-version]" << std::endl;
   std::cerr << "To pause and unpause: pkill -USR1 Protonect" << std::endl;
   size_t executable_name_idx = program_path.rfind("Protonect");
 
@@ -145,15 +146,7 @@ int main(int argc, char *argv[])
   libfreenect2::PacketPipeline *pipeline = 0;
 /// [context]
 
-/// [discovery]
-  if(freenect2.enumerateDevices() == 0)
-  {
-    std::cout << "no device connected!" << std::endl;
-    return -1;
-  }
-
-  std::string serial = freenect2.getDefaultDeviceSerialNumber();
-/// [discovery]
+  std::string serial = "";
 
   bool viewer_enabled = true;
 
@@ -161,7 +154,12 @@ int main(int argc, char *argv[])
   {
     const std::string arg(argv[argI]);
 
-    if(arg == "cpu")
+    if(arg == "-help" || arg == "--help" || arg == "-h" || arg == "-v" || arg == "--version" || arg == "-version")
+    {
+      // Just let the initial lines display at the beginning of main
+      return 0;
+    }
+    else if(arg == "cpu")
     {
       if(!pipeline)
 /// [pipeline]
@@ -190,7 +188,7 @@ int main(int argc, char *argv[])
     {
       serial = arg;
     }
-    else if(arg == "-noviewer")
+    else if(arg == "-noviewer" || arg == "--noviewer")
     {
       viewer_enabled = false;
     }
@@ -199,6 +197,19 @@ int main(int argc, char *argv[])
       std::cout << "Unknown argument: " << arg << std::endl;
     }
   }
+
+/// [discovery]
+  if(freenect2.enumerateDevices() == 0)
+  {
+    std::cout << "no device connected!" << std::endl;
+    return -1;
+  }
+
+  if (serial == "")
+  {
+    serial = freenect2.getDefaultDeviceSerialNumber();
+  }
+/// [discovery]
 
   if(pipeline)
   {

--- a/include/libfreenect2/config.h.in
+++ b/include/libfreenect2/config.h.in
@@ -27,6 +27,9 @@
 #ifndef LIBFREENECT2_CONFIG_H
 #define LIBFREENECT2_CONFIG_H
 
+#define LIBFREENECT2_VERSION "@PROJECT_VER@"
+#define LIBFREENECT2_API_VERSION ((@PROJECT_VER_MAJOR@ << 16) | @PROJECT_VER_MINOR@)
+
 #ifdef _MSC_VER
 #define LIBFREENECT2_PACK( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop) )
 #else


### PR DESCRIPTION
Thought it would make sense to add in a version string into the library/Protonect CLI output. The -help option just displays the stderr output that's been written at the beginning of main and subsequently exits. I can refactor it more but I thought I'd keep the changes simple for now and open this for feedback.