### PR TITLE
Add accessors for the various depth tables.

### DIFF
--- a/include/libfreenect2/packet_pipeline.h
+++ b/include/libfreenect2/packet_pipeline.h
@@ -31,6 +31,8 @@
 
 #include <libfreenect2/config.h>
 
+#include <stdlib.h>
+
 namespace libfreenect2
 {
 
@@ -71,6 +73,13 @@ protected:
  public:
    DumpPacketPipeline();
    virtual ~DumpPacketPipeline();
+
+   // These are all required to decode depth data
+   const unsigned char* getDepthP0Tables(size_t* length);
+
+   const float* getDepthXTable(size_t* length);
+   const float* getDepthZTable(size_t* length);
+   const short* getDepthLookupTable(size_t* length);
  };
 
 /** Pipeline with CPU depth processing. */

--- a/src/packet_pipeline.cpp
+++ b/src/packet_pipeline.cpp
@@ -31,6 +31,7 @@
 #include <libfreenect2/data_callback.h>
 #include <libfreenect2/rgb_packet_stream_parser.h>
 #include <libfreenect2/depth_packet_stream_parser.h>
+#include <libfreenect2/protocol/response.h>
 
 namespace libfreenect2
 {
@@ -137,5 +138,25 @@ DumpPacketPipeline::DumpPacketPipeline()
 }
 
 DumpPacketPipeline::~DumpPacketPipeline() {}
+
+const unsigned char* DumpPacketPipeline::getDepthP0Tables(size_t* length) {
+  *length = sizeof(libfreenect2::protocol::P0TablesResponse);
+  return static_cast<DumpDepthPacketProcessor*>(getDepthPacketProcessor())->getP0Tables();
+}
+
+const float* DumpPacketPipeline::getDepthXTable(size_t* length) {
+  *length = DepthPacketProcessor::TABLE_SIZE;
+  return static_cast<DumpDepthPacketProcessor*>(getDepthPacketProcessor())->getXTable();
+}
+
+const float* DumpPacketPipeline::getDepthZTable(size_t* length) {
+  *length = DepthPacketProcessor::TABLE_SIZE;
+  return static_cast<DumpDepthPacketProcessor*>(getDepthPacketProcessor())->getZTable();
+}
+
+const short* DumpPacketPipeline::getDepthLookupTable(size_t* length) {
+  *length = DepthPacketProcessor::LUT_SIZE;
+  return static_cast<DumpDepthPacketProcessor*>(getDepthPacketProcessor())->getLookupTable();
+}
 
 } /* namespace libfreenect2 */


### PR DESCRIPTION
Follow on to #551 

@xlz I had to add `size_t *len` to the accessors since there is no good way to get the lengths out of the library without moving around things and declaring a new constant for `sizeof(P0TableResponse)`

Let me know if you have a preferred alternate approach.