### PR TITLE
Usb error reporting

### DIFF
--- a/examples/Protonect.cpp
+++ b/examples/Protonect.cpp
@@ -245,7 +245,8 @@ int main(int argc, char *argv[])
 /// [listeners]
 
 /// [start]
-  dev->start();
+  if (!dev->start())
+    return -1;
 
   std::cout << "device serial: " << dev->getSerialNumber() << std::endl;
   std::cout << "device firmware: " << dev->getFirmwareVersion() << std::endl;

--- a/include/internal/libfreenect2/protocol/command.h
+++ b/include/internal/libfreenect2/protocol/command.h
@@ -28,6 +28,7 @@
 #define COMMAND_H_
 
 #include <stdint.h>
+#include "libfreenect2/protocol/response.h"
 
 #define KCMD_READ_FIRMWARE_VERSIONS 0x02
 #define KCMD_INIT_STREAMS 0x09
@@ -85,12 +86,13 @@ struct CommandBase
 
   virtual uint32_t sequence() const = 0;
   virtual uint32_t maxResponseLength() const = 0;
+  virtual uint32_t minResponseLength() const = 0;
 
   virtual const uint8_t *data() const = 0;
   virtual uint32_t size() const = 0;
 };
 
-template<uint32_t CommandId, uint32_t MaxResponseLength, uint32_t NParam>
+template<uint32_t CommandId, uint32_t MaxResponseLength, uint32_t MinResponseLength, uint32_t NParam>
 class Command : public CommandBase
 {
 public:
@@ -99,6 +101,8 @@ public:
   static const uint32_t MagicNumber = 0x06022009;
   static const uint32_t Size = sizeof(Data);
 
+  uint32_t min_response_length;
+
   Command(uint32_t seq)
   {
     data_.magic = MagicNumber;
@@ -106,6 +110,7 @@ public:
     data_.max_response_length = MaxResponseLength;
     data_.command = CommandId;
     data_.reserved0 = 0;
+    min_response_length = MinResponseLength;
   }
 
   virtual ~Command()
@@ -120,6 +125,11 @@ public:
   virtual uint32_t maxResponseLength() const
   {
     return data_.max_response_length;
+  }
+
+  virtual uint32_t minResponseLength() const
+  {
+    return min_response_length;
   }
 
   virtual const uint8_t *data() const
@@ -137,26 +147,35 @@ protected:
 };
 
 template<uint32_t CommandId, uint32_t MaxResponseLength>
-struct CommandWith0Params : public Command<CommandId, MaxResponseLength, 0>
+struct CommandWith0Params : public Command<CommandId, MaxResponseLength, MaxResponseLength, 0>
 {
-  CommandWith0Params(uint32_t seq) : Command<CommandId, MaxResponseLength, 0>(seq)
+  CommandWith0Params(uint32_t seq) : Command<CommandId, MaxResponseLength, MaxResponseLength, 0>(seq)
   {
   }
 };
 
 template<uint32_t CommandId, uint32_t MaxResponseLength, uint32_t Param1>
-struct CommandWith1Param : public Command<CommandId, MaxResponseLength, 1>
+struct CommandWith1Param : public Command<CommandId, MaxResponseLength, MaxResponseLength, 1>
 {
-  CommandWith1Param(uint32_t seq) : Command<CommandId, MaxResponseLength, 1>(seq)
+  CommandWith1Param(uint32_t seq) : Command<CommandId, MaxResponseLength, MaxResponseLength, 1>(seq)
+  {
+    this->data_.parameters[0] = Param1;
+  }
+};
+
+template<uint32_t CommandId, uint32_t MaxResponseLength, uint32_t MinResponseLength, uint32_t Param1>
+struct CommandWith1ParamLarge : public Command<CommandId, MaxResponseLength, MinResponseLength, 1>
+{
+  CommandWith1ParamLarge(uint32_t seq) : Command<CommandId, MaxResponseLength, MinResponseLength, 1>(seq)
   {
     this->data_.parameters[0] = Param1;
   }
 };
 
 template<uint32_t CommandId, uint32_t MaxResponseLength, uint32_t Param1, uint32_t Param2 = 0, uint32_t Param3 = 0, uint32_t Param4 = 0>
-struct CommandWith4Params : public Command<CommandId, MaxResponseLength, 4>
+struct CommandWith4Params : public Command<CommandId, MaxResponseLength, MaxResponseLength, 4>
 {
-  CommandWith4Params(uint32_t seq) : Command<CommandId, MaxResponseLength, 4>(seq)
+  CommandWith4Params(uint32_t seq) : Command<CommandId, MaxResponseLength, MaxResponseLength, 4>(seq)
   {
     this->data_.parameters[0] = Param1;
     this->data_.parameters[1] = Param2;
@@ -172,9 +191,9 @@ typedef CommandWith0Params<KCMD_READ_HARDWARE_INFO, 0x5C> ReadHardwareInfoComman
 typedef CommandWith0Params<KCMD_INIT_STREAMS, 0x00> InitStreamsCommand;
 
 typedef CommandWith1Param<KCMD_READ_DATA_PAGE, 0x80, 0x01> ReadSerialNumberCommand;
-typedef CommandWith1Param<KCMD_READ_DATA_PAGE, 0x1C0000, 0x02> ReadP0TablesCommand;
-typedef CommandWith1Param<KCMD_READ_DATA_PAGE, 0x1C0000, 0x03> ReadDepthCameraParametersCommand;
-typedef CommandWith1Param<KCMD_READ_DATA_PAGE, 0x1C0000, 0x04> ReadRgbCameraParametersCommand;
+typedef CommandWith1ParamLarge<KCMD_READ_DATA_PAGE, 0x1C0000, sizeof(P0TablesResponse), 0x02> ReadP0TablesCommand;
+typedef CommandWith1ParamLarge<KCMD_READ_DATA_PAGE, 0x1C0000, sizeof(DepthCameraParamsResponse), 0x03> ReadDepthCameraParametersCommand;
+typedef CommandWith1ParamLarge<KCMD_READ_DATA_PAGE, 0x1C0000, sizeof(RgbCameraParamsResponse), 0x04> ReadRgbCameraParametersCommand;
 
 typedef CommandWith1Param<KCMD_READ_STATUS, 0x04, 0x090000> ReadStatus0x090000Command;
 typedef CommandWith1Param<KCMD_READ_STATUS, 0x04, 0x100007> ReadStatus0x100007Command;

--- a/include/internal/libfreenect2/protocol/command_transaction.h
+++ b/include/internal/libfreenect2/protocol/command_transaction.h
@@ -55,7 +55,7 @@ private:
 
   bool send(const CommandBase& command);
 
-  bool receive(Result& result);
+  bool receive(Result& result, uint32_t min_length);
 
   bool isResponseCompleteResult(Result& result, uint32_t sequence);
 };

--- a/include/internal/libfreenect2/protocol/command_transaction.h
+++ b/include/internal/libfreenect2/protocol/command_transaction.h
@@ -27,6 +27,7 @@
 #ifndef COMMAND_TRANSACTION_H_
 #define COMMAND_TRANSACTION_H_
 
+#include <vector>
 #include <libusb.h>
 #include <libfreenect2/protocol/command.h>
 
@@ -41,39 +42,20 @@ public:
   static const int ResponseCompleteLength = 16;
   static const uint32_t ResponseCompleteMagic = 0x0A6FE000;
 
-  enum ResultCode
-  {
-    Success,
-    Error
-  };
-
-  struct Result
-  {
-    ResultCode code;
-
-    unsigned char *data;
-    int capacity, length;
-
-    Result();
-    ~Result();
-
-    void allocate(size_t size);
-    void deallocate();
-    bool notSuccessfulThenDeallocate();
-  };
+  typedef std::vector<unsigned char> Result;
 
   CommandTransaction(libusb_device_handle *handle, int inbound_endpoint, int outbound_endpoint);
   ~CommandTransaction();
 
-  void execute(const CommandBase& command, Result& result);
+  bool execute(const CommandBase& command, Result& result);
 private:
   libusb_device_handle *handle_;
   int inbound_endpoint_, outbound_endpoint_, timeout_;
   Result response_complete_result_;
 
-  ResultCode send(const CommandBase& command);
+  bool send(const CommandBase& command);
 
-  void receive(Result& result);
+  bool receive(Result& result);
 
   bool isResponseCompleteResult(Result& result, uint32_t sequence);
 };

--- a/include/internal/libfreenect2/protocol/response.h
+++ b/include/internal/libfreenect2/protocol/response.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include <algorithm>
 #include <libfreenect2/config.h>
+#include <libfreenect2/libfreenect2.hpp>
 
 namespace libfreenect2
 {
@@ -44,8 +45,9 @@ class SerialNumberResponse
 private:
   std::string serial_;
 public:
-  SerialNumberResponse(const unsigned char *data, int length)
+  SerialNumberResponse(const std::vector<unsigned char> &data)
   {
+    int length = data.size();
     char *c = new char[length / 2 + 1]();
 
     for(int i = 0, j = 0; i < length; i += 2, ++j)
@@ -85,10 +87,11 @@ private:
 
   std::vector<FWSubsystemVersion> versions_;
 public:
-  FirmwareVersionResponse(const unsigned char *data, int length)
+  FirmwareVersionResponse(const std::vector<unsigned char> &data)
   {
+    int length = data.size();
     int n = length / sizeof(FWSubsystemVersion);
-    const FWSubsystemVersion *sv = reinterpret_cast<const FWSubsystemVersion *>(data);
+    const FWSubsystemVersion *sv = reinterpret_cast<const FWSubsystemVersion *>(&data[0]);
 
     for(int i = 0; i < 7 && i < n; ++i)
     {
@@ -112,13 +115,30 @@ public:
   }
 };
 
+class Status0x090000Response
+{
+private:
+  uint32_t status_;
+public:
+  Status0x090000Response(const std::vector<unsigned char> &data)
+  {
+    status_ = *reinterpret_cast<const uint32_t *>(&data[0]);
+  }
+
+  uint32_t toNumber()
+  {
+    return status_;
+  }
+};
+
 class GenericResponse
 {
 private:
   std::string dump_;
 public:
-  GenericResponse(const unsigned char *data, int length)
+  GenericResponse(const std::vector<unsigned char> &data)
   {
+    int length = data.size();
     std::stringstream dump;
     dump << length << " bytes of raw data" << std::endl;
 
@@ -193,6 +213,46 @@ LIBFREENECT2_PACK(struct RgbCameraParamsResponse
   // matches the depth image aspect ratio of 512*424 very closely
   float table1[28 * 23 * 4];
   float table2[28 * 23];
+
+  RgbCameraParamsResponse(const std::vector<unsigned char> &data)
+  {
+    *this = *reinterpret_cast<const RgbCameraParamsResponse *>(&data[0]);
+  }
+
+  Freenect2Device::ColorCameraParams toColorCameraParams()
+  {
+    Freenect2Device::ColorCameraParams params;
+    params.fx = color_f;
+    params.fy = color_f;
+    params.cx = color_cx;
+    params.cy = color_cy;
+
+    params.shift_d = shift_d;
+    params.shift_m = shift_m;
+
+    params.mx_x3y0 = mx_x3y0; // xxx
+    params.mx_x0y3 = mx_x0y3; // yyy
+    params.mx_x2y1 = mx_x2y1; // xxy
+    params.mx_x1y2 = mx_x1y2; // yyx
+    params.mx_x2y0 = mx_x2y0; // xx
+    params.mx_x0y2 = mx_x0y2; // yy
+    params.mx_x1y1 = mx_x1y1; // xy
+    params.mx_x1y0 = mx_x1y0; // x
+    params.mx_x0y1 = mx_x0y1; // y
+    params.mx_x0y0 = mx_x0y0; // 1
+
+    params.my_x3y0 = my_x3y0; // xxx
+    params.my_x0y3 = my_x0y3; // yyy
+    params.my_x2y1 = my_x2y1; // xxy
+    params.my_x1y2 = my_x1y2; // yyx
+    params.my_x2y0 = my_x2y0; // xx
+    params.my_x0y2 = my_x0y2; // yy
+    params.my_x1y1 = my_x1y1; // xy
+    params.my_x1y0 = my_x1y0; // x
+    params.my_x0y1 = my_x0y1; // y
+    params.my_x0y0 = my_x0y0; // 1
+    return params;
+  }
 });
 
 
@@ -214,6 +274,26 @@ LIBFREENECT2_PACK(struct DepthCameraParamsResponse
   float k3;
 
   float unknown1[13]; // assumed to be always zero
+
+  DepthCameraParamsResponse(const std::vector<unsigned char> &data)
+  {
+    *this = *reinterpret_cast<const DepthCameraParamsResponse *>(&data[0]);
+  }
+
+  Freenect2Device::IrCameraParams toIrCameraParams()
+  {
+    Freenect2Device::IrCameraParams params;
+    params.fx = fx;
+    params.fy = fy;
+    params.cx = cx;
+    params.cy = cy;
+    params.k1 = k1;
+    params.k2 = k2;
+    params.k3 = k3;
+    params.p1 = p1;
+    params.p2 = p2;
+    return params;
+  }
 });
 
 // "P0" coefficient tables, input to the deconvolution code

--- a/include/internal/libfreenect2/usb/transfer_pool.h
+++ b/include/internal/libfreenect2/usb/transfer_pool.h
@@ -51,7 +51,7 @@ public:
 
   void disableSubmission();
 
-  void submit(size_t num_parallel_transfers);
+  bool submit(size_t num_parallel_transfers);
 
   void cancel();
 

--- a/src/command_transaction.cpp
+++ b/src/command_transaction.cpp
@@ -37,155 +37,102 @@ namespace libfreenect2
 {
 namespace protocol
 {
-CommandTransaction::Result::Result() :
-    code(Error), data(NULL), capacity(0), length(0)
-{
-}
-
-CommandTransaction::Result::~Result()
-{
-  deallocate();
-}
-
-void CommandTransaction::Result::allocate(size_t size)
-{
-  if ((size_t)capacity != size)
-  {
-    deallocate();
-    data = new unsigned char[size];
-    capacity = size;
-  }
-  length = 0;
-}
-
-void CommandTransaction::Result::deallocate()
-{
-  if (data != NULL)
-  {
-    delete[] data;
-  }
-  length = 0;
-  capacity = 0;
-}
-
-bool CommandTransaction::Result::notSuccessfulThenDeallocate()
-{
-  bool not_successful = (code != Success);
-
-  if (not_successful)
-  {
-    deallocate();
-  }
-
-  return not_successful;
-}
-
 CommandTransaction::CommandTransaction(libusb_device_handle *handle, int inbound_endpoint, int outbound_endpoint) :
   handle_(handle),
   inbound_endpoint_(inbound_endpoint),
   outbound_endpoint_(outbound_endpoint),
   timeout_(1000)
 {
-  response_complete_result_.allocate(ResponseCompleteLength);
+  response_complete_result_.resize(ResponseCompleteLength);
 }
 
 CommandTransaction::~CommandTransaction() {}
 
-void CommandTransaction::execute(const CommandBase& command, Result& result)
+bool CommandTransaction::execute(const CommandBase& command, Result& result)
 {
-  result.allocate(command.maxResponseLength());
+  result.resize(command.maxResponseLength());
 
   // send command
-  result.code = send(command);
-
-  if(result.notSuccessfulThenDeallocate()) return;
-
-  bool complete = false;
+  if (!send(command))
+    return false;
 
   // receive response data
   if(command.maxResponseLength() > 0)
   {
-    receive(result);
-    complete = isResponseCompleteResult(result, command.sequence());
-
-    if(complete)
+    if (!receive(result))
+      return false;
+    if (isResponseCompleteResult(result, command.sequence()))
     {
       LOG_ERROR << "received premature response complete!";
-      result.code = Error;
+      return false;
     }
-
-    if(result.notSuccessfulThenDeallocate()) return;
   }
 
   // receive response complete
-  receive(response_complete_result_);
-  complete = isResponseCompleteResult(response_complete_result_, command.sequence());
-
-  if(!complete)
+  if (!receive(response_complete_result_))
+    return false;
+  if (!isResponseCompleteResult(response_complete_result_, command.sequence()))
   {
     LOG_ERROR << "missing response complete!";
-    result.code = Error;
+    return false;
   }
 
-  result.notSuccessfulThenDeallocate();
+  return true;
 }
 
-CommandTransaction::ResultCode CommandTransaction::send(const CommandBase& command)
+bool CommandTransaction::send(const CommandBase& command)
 {
-  ResultCode code = Success;
-
   int transferred_bytes = 0;
   int r = libusb_bulk_transfer(handle_, outbound_endpoint_, const_cast<uint8_t *>(command.data()), command.size(), &transferred_bytes, timeout_);
 
   if(r != LIBUSB_SUCCESS)
   {
     LOG_ERROR << "bulk transfer failed: " << WRITE_LIBUSB_ERROR(r);
-    code = Error;
+    return false;
   }
 
   if((size_t)transferred_bytes != command.size())
   {
     LOG_ERROR << "sent number of bytes differs from expected number! expected: " << command.size() << " got: " << transferred_bytes;
-    code = Error;
+    return false;
   }
 
-  return code;
+  return true;
 }
 
-void CommandTransaction::receive(CommandTransaction::Result& result)
+bool CommandTransaction::receive(CommandTransaction::Result& result)
 {
-  result.code = Success;
-  result.length = 0;
+  int length = 0;
 
-  int r = libusb_bulk_transfer(handle_, inbound_endpoint_, result.data, result.capacity, &result.length, timeout_);
+  int r = libusb_bulk_transfer(handle_, inbound_endpoint_, &result[0], result.size(), &length, timeout_);
+  result.resize(length);
 
   if(r != LIBUSB_SUCCESS)
   {
     LOG_ERROR << "bulk transfer failed: " << WRITE_LIBUSB_ERROR(r);
-    result.code = Error;
+    return false;
   }
+
+  return true;
 }
 
 bool CommandTransaction::isResponseCompleteResult(CommandTransaction::Result& result, uint32_t sequence)
 {
-  bool complete = false;
-
-  if(result.code == Success && result.length == ResponseCompleteLength)
+  if(result.size() == ResponseCompleteLength)
   {
-    uint32_t *data = reinterpret_cast<uint32_t *>(result.data);
+    uint32_t *data = reinterpret_cast<uint32_t *>(&result[0]);
 
     if(data[0] == ResponseCompleteMagic)
     {
-      complete = true;
-
       if(data[1] != sequence)
       {
         LOG_ERROR << "response complete with wrong sequence number! expected: " << sequence << " got: " << data[1];
       }
+      return true;
     }
   }
 
-  return complete;
+  return false;
 }
 
 

--- a/src/libfreenect2.cpp
+++ b/src/libfreenect2.cpp
@@ -754,8 +754,6 @@ bool Freenect2DeviceImpl::start()
   for (uint32_t status = 0, last = 0; (status & 1) == 0; last = status)
   {
     if (!command_tx_.execute(ReadStatus0x090000Command(nextCommandSeq()), result)) return false;
-    if ((size_t)result.size() < sizeof(uint32_t))
-      continue; //TODO should report error
     status = *reinterpret_cast<const uint32_t *>(&result[0]);
     if (status != last)
       LOG_DEBUG << "status 0x090000: " << status;
@@ -768,8 +766,7 @@ bool Freenect2DeviceImpl::start()
   usb_control_.setIrInterfaceState(UsbControl::Enabled);
 
   if (!command_tx_.execute(ReadStatus0x090000Command(nextCommandSeq()), result)) return false;
-  if ((size_t)result.size() >= sizeof(uint32_t))
-    LOG_DEBUG << "status 0x090000: " << *reinterpret_cast<const uint32_t *>(&result[0]);
+  LOG_DEBUG << "status 0x090000: " << *reinterpret_cast<const uint32_t *>(&result[0]);
 
   if (!command_tx_.execute(SetStreamEnabledCommand(nextCommandSeq()), result)) return false;
 

--- a/src/transfer_pool.cpp
+++ b/src/transfer_pool.cpp
@@ -77,18 +77,18 @@ void TransferPool::deallocate()
   }
 }
 
-void TransferPool::submit(size_t num_parallel_transfers)
+bool TransferPool::submit(size_t num_parallel_transfers)
 {
   if(!enable_submit_)
   {
     LOG_WARNING << "transfer submission disabled!";
-    return;
+    return false;
   }
 
   if(transfers_.size() < num_parallel_transfers)
   {
     LOG_ERROR << "too few idle transfers!";
-    return;
+    return false;
   }
 
   size_t failcount = 0;
@@ -108,7 +108,12 @@ void TransferPool::submit(size_t num_parallel_transfers)
   }
 
   if (failcount == num_parallel_transfers)
+  {
     LOG_ERROR << "all submissions failed. Try debugging with environment variable: LIBUSB_DEBUG=3.";
+    return false;
+  }
+
+  return true;
 }
 
 void TransferPool::cancel()


### PR DESCRIPTION
* Properly stop execution when usb errors happen (libusb errors, short command response).
* Use std::vector instead of manual memory management in CommandTransaction