### PR TITLE
Add ability to disable RGB or depth stream

### DIFF
--- a/include/internal/libfreenect2/usb/transfer_pool.h
+++ b/include/internal/libfreenect2/usb/transfer_pool.h
@@ -51,6 +51,8 @@ public:
 
   void disableSubmission();
 
+  bool enabled();
+
   void submit(size_t num_parallel_transfers);
 
   void cancel();

--- a/include/libfreenect2/libfreenect2.hpp
+++ b/include/libfreenect2/libfreenect2.hpp
@@ -159,7 +159,7 @@ public:
   /** Provide your listener to receive IR and depth frames. */
   virtual void setIrAndDepthFrameListener(FrameListener* ir_frame_listener) = 0;
 
-  /** Start data processing.
+  /** Start data processing with both RGB and depth streams.
    * All above configuration must only be called before start() or after stop().
    *
    * FrameListener will receive frames when the device is running.
@@ -167,6 +167,15 @@ public:
    * @return Undefined. To be defined in 0.2.
    */
   virtual bool start() = 0;
+
+  /** Start data processing with or without some streams.
+   * FrameListener will receive enabled frames when the device is running.
+   *
+   * @param rgb Whether to enable RGB stream.
+   * @param depth Whether to enable depth stream.
+   * @return Undefined. To be defined in 0.2.
+   */
+  virtual bool startStreams(bool rgb, bool depth) = 0;
 
   /** Stop data processing.
    *

--- a/src/transfer_pool.cpp
+++ b/src/transfer_pool.cpp
@@ -61,6 +61,11 @@ void TransferPool::disableSubmission()
   enable_submit_ = false;
 }
 
+bool TransferPool::enabled()
+{
+  return enable_submit_;
+}
+
 void TransferPool::deallocate()
 {
   for(TransferQueue::iterator it = transfers_.begin(); it != transfers_.end(); ++it)


### PR DESCRIPTION
Users want to save USB bandwidth and CPU if they don't need RGB or depth.

* Add new `startStreams(bool rgb, bool depth)` to Freenect2Device
* Give an example stream selection with new options `-norgb -nodepth` to Protonect

