### PR TITLE
Delay start stream in OpenNI2 driver

### DIFF
--- a/src/openni2/ColorStream.cpp
+++ b/src/openni2/ColorStream.cpp
@@ -35,7 +35,7 @@ const float ColorStream::DIAGONAL_FOV = 73.9 * (M_PI / 180);
 const float ColorStream::HORIZONTAL_FOV = 62 * (M_PI / 180);
 const float ColorStream::VERTICAL_FOV = 48.6 * (M_PI / 180);
 
-ColorStream::ColorStream(libfreenect2::Freenect2Device* pDevice, Freenect2Driver::Registration *reg) : VideoStream(pDevice, reg)
+ColorStream::ColorStream(Device* driver_dev, libfreenect2::Freenect2Device* pDevice, Freenect2Driver::Registration *reg) : VideoStream(driver_dev, pDevice, reg)
 {
   video_mode = makeOniVideoMode(ONI_PIXEL_FORMAT_RGB888, 1920, 1080, 30);
   setVideoMode(video_mode);

--- a/src/openni2/ColorStream.hpp
+++ b/src/openni2/ColorStream.hpp
@@ -54,7 +54,7 @@ namespace Freenect2Driver
     bool auto_exposure;
 
   public:
-    ColorStream(libfreenect2::Freenect2Device* pDevice, Freenect2Driver::Registration *reg);
+    ColorStream(Device* driver_dev, libfreenect2::Freenect2Device* pDevice, Freenect2Driver::Registration *reg);
     //~ColorStream() { }
 
     OniStatus setImageRegistrationMode(OniImageRegistrationMode mode);

--- a/src/openni2/DepthStream.cpp
+++ b/src/openni2/DepthStream.cpp
@@ -45,7 +45,7 @@ const unsigned long long DepthStream::ZERO_PLANE_DISTANCE_VAL;
 const double DepthStream::ZERO_PLANE_PIXEL_SIZE_VAL = 0.10520000010728836;
 const double DepthStream::EMITTER_DCMOS_DISTANCE_VAL = 7.5;
 
-DepthStream::DepthStream(libfreenect2::Freenect2Device* pDevice, Freenect2Driver::Registration *reg) : VideoStream(pDevice, reg)
+DepthStream::DepthStream(Device* driver_dev, libfreenect2::Freenect2Device* pDevice, Freenect2Driver::Registration *reg) : VideoStream(driver_dev, pDevice, reg)
 {
   //video_mode = makeOniVideoMode(ONI_PIXEL_FORMAT_DEPTH_1_MM, 512, 424, 30);
   video_mode = makeOniVideoMode(ONI_PIXEL_FORMAT_DEPTH_1_MM, 640, 480, 30);

--- a/src/openni2/DepthStream.hpp
+++ b/src/openni2/DepthStream.hpp
@@ -58,7 +58,7 @@ namespace Freenect2Driver
     void populateFrame(libfreenect2::Frame* srcFrame, int srcX, int srcY, OniFrame* dstFrame, int dstX, int dstY, int width, int height) const;
 
   public:
-    DepthStream(libfreenect2::Freenect2Device* pDevice, Freenect2Driver::Registration *reg);
+    DepthStream(Device* driver_dev, libfreenect2::Freenect2Device* pDevice, Freenect2Driver::Registration *reg);
     //~DepthStream() { }
 
     OniImageRegistrationMode getImageRegistrationMode() const;

--- a/src/openni2/IrStream.cpp
+++ b/src/openni2/IrStream.cpp
@@ -34,7 +34,7 @@ using namespace Freenect2Driver;
 const float IrStream::HORIZONTAL_FOV = 58.5 * (M_PI / 180);
 const float IrStream::VERTICAL_FOV = 45.6 * (M_PI / 180);
 
-IrStream::IrStream(libfreenect2::Freenect2Device* pDevice, Freenect2Driver::Registration *reg) : VideoStream(pDevice, reg)
+IrStream::IrStream(Device* driver_dev, libfreenect2::Freenect2Device* pDevice, Freenect2Driver::Registration *reg) : VideoStream(driver_dev, pDevice, reg)
 {
   video_mode = makeOniVideoMode(ONI_PIXEL_FORMAT_GRAY16, 512, 424, 30);
   setVideoMode(video_mode);

--- a/src/openni2/IrStream.hpp
+++ b/src/openni2/IrStream.hpp
@@ -45,7 +45,7 @@ namespace Freenect2Driver
     void populateFrame(libfreenect2::Frame* srcFrame, int srcX, int srcY, OniFrame* dstFrame, int dstX, int dstY, int width, int height) const;
 
   public:
-    IrStream(libfreenect2::Freenect2Device* pDevice, Freenect2Driver::Registration *reg);
+    IrStream(Device* driver_dev, libfreenect2::Freenect2Device* pDevice, Freenect2Driver::Registration *reg);
     //~IrStream() { }
 
     // from StreamBase

--- a/src/openni2/VideoStream.cpp
+++ b/src/openni2/VideoStream.cpp
@@ -148,10 +148,15 @@ bool VideoStream::buildFrame(libfreenect2::Frame* lf2Frame)
 
 OniStatus VideoStream::start()
 {
+  driver_dev->start();
   running = true;
   return ONI_STATUS_OK;
 }
-void VideoStream::stop() { running = false; }
+void VideoStream::stop()
+{
+  driver_dev->stop();
+  running = false;
+}
 
 // only add to property handlers if the property is generic to all children
 // otherwise, implement in child and call these in default case

--- a/src/openni2/VideoStream.cpp
+++ b/src/openni2/VideoStream.cpp
@@ -76,9 +76,10 @@ void VideoStream::raisePropertyChanged(int propertyId, const void* data, int dat
     StreamBase::raisePropertyChanged(propertyId, data, dataSize);
 }
 
-VideoStream::VideoStream(libfreenect2::Freenect2Device* device, Freenect2Driver::Registration *reg) :
+VideoStream::VideoStream(Device* drvdev, libfreenect2::Freenect2Device* device, Freenect2Driver::Registration *reg) :
   frame_id(1),
   device(device),
+  driver_dev(drvdev),
   running(false),
   mirroring(false),
   reg(reg),

--- a/src/openni2/VideoStream.hpp
+++ b/src/openni2/VideoStream.hpp
@@ -34,6 +34,13 @@
 
 namespace Freenect2Driver
 {
+  class Device : public oni::driver::DeviceBase
+  {
+  public:
+    virtual void start() = 0;
+    virtual void stop() = 0;
+  };
+
   class VideoStream : public oni::driver::StreamBase
   {
   private:
@@ -43,6 +50,7 @@ namespace Freenect2Driver
   protected:
     virtual OniSensorType getSensorType() const = 0;
     libfreenect2::Freenect2Device* device;
+    Device* driver_dev;
     bool running; // buildFrame() does something iff true
     OniVideoMode video_mode;
     OniCropping cropping;
@@ -58,7 +66,7 @@ namespace Freenect2Driver
     void raisePropertyChanged(int propertyId, const void* data, int dataSize);
 
   public:
-    VideoStream(libfreenect2::Freenect2Device* device, Freenect2Driver::Registration *reg);
+    VideoStream(Device* driver_dev, libfreenect2::Freenect2Device* device, Freenect2Driver::Registration *reg);
 
     OniSensorInfo getSensorInfo();
 


### PR DESCRIPTION
This fix delay calling Freenect2Device::start() and avoid calling close() which issue the shutdown USB command to the sensor device. You should not call Freenect2Device::close() every time OpenNI2 device closed because some OpenNI2 client call open/close repeatedly only to probe some properties of the device.