### PR TITLE
Error when using C++11 std threading

### DIFF
--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -68,7 +68,7 @@ public:
   {
     unique_lock guard(used_lock);
     while (used[0] && used[1])
-      available_cond.wait(used_lock);
+      WAIT_CONDITION(available_cond, used_lock, guard);
 
     if (!used[0]) {
       if (buffers[0] == NULL)


### PR DESCRIPTION
```
[ 31%] Building CXX object CMakeFiles/freenect2.dir/src/allocator.cpp.o
/Users/fran6co/Code/libfreenect2/src/allocator.cpp:71:22: error: no matching member function for call to 'wait'
      available_cond.wait(used_lock);
      ~~~~~~~~~~~~~~~^~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__mutex_base:287:10: note: candidate function not viable: no known conversion from 'mutex'
      (aka 'std::__1::mutex') to 'unique_lock<std::__1::mutex> &' for 1st argument
    void wait(unique_lock<mutex>& __lk) _NOEXCEPT;
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__mutex_base:341:21: note: candidate function template not viable: requires 2 arguments, but 1 was
      provided
condition_variable::wait(unique_lock<mutex>& __lk, _Predicate __pred)
                    ^
```