### PR TITLE
Create ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Please perform the following steps before submitting an issue, and confirm by checking the boxes:
+
+- [ ] I have read the README and particularly the FAQ section.
+- [ ] I have checked the Wiki, particularly the USB section.
+- [ ] I have filled out the information below.
+
+### Which particular branch or release are you working on?
+
+### What is your operating system (and kernel version, if applicable)?
+
+### What USB*3* controller are you using?


### PR DESCRIPTION
Github now supports issue templates, which I think are long overdue (https://github.com/blog/2111-issue-and-pull-request-templates). Here's a draft for libfreenect2.