### PR TITLE
Opencl improvements

### DIFF
--- a/include/internal/libfreenect2/depth_packet_processor.h
+++ b/include/internal/libfreenect2/depth_packet_processor.h
@@ -175,7 +175,9 @@ public:
   virtual void loadXZTables(const float *xtable, const float *ztable);
   virtual void loadLookupTable(const short *lut);
 
+  virtual bool good();
   virtual const char *name() { return "OpenCL"; }
+
   virtual void process(const DepthPacket &packet);
 protected:
   virtual Allocator *getAllocator();

--- a/include/internal/libfreenect2/depth_packet_processor.h
+++ b/include/internal/libfreenect2/depth_packet_processor.h
@@ -177,6 +177,8 @@ public:
 
   virtual const char *name() { return "OpenCL"; }
   virtual void process(const DepthPacket &packet);
+protected:
+  virtual Allocator *getAllocator();
 private:
   OpenCLDepthPacketProcessorImpl *impl_;
 };

--- a/src/opencl_depth_packet_processor.cl
+++ b/src/opencl_depth_packet_processor.cl
@@ -24,13 +24,17 @@
  * either License.
  */
 
+#define PHASE_SIN (float3)(PHASE_IN_RAD0_SIN, PHASE_IN_RAD1_SIN, PHASE_IN_RAD2_SIN)
+#define PHASE_COS (float3)(PHASE_IN_RAD0_COS, PHASE_IN_RAD1_COS, PHASE_IN_RAD2_COS)
+#define AB_MULTIPLIER_PER_FRQ (float3)(AB_MULTIPLIER_PER_FRQ0, AB_MULTIPLIER_PER_FRQ1, AB_MULTIPLIER_PER_FRQ2)
+
 /*******************************************************************************
  * Process pixel stage 1
  ******************************************************************************/
 
 float decodePixelMeasurement(global const ushort *data, global const short *lut11to16, const uint sub, const uint x, const uint y)
 {
-  uint row_idx = (424 * sub + (y < 212 ? y + 212 : 423 - y)) * 352;
+  uint row_idx = (424 * sub + y) * 352;
   uint idx = (((x >> 2) + ((x << 7) & BFI_BITMASK)) * 11) & (uint)0xffffffff;
 
   uint col_idx = idx >> 4;
@@ -43,60 +47,50 @@ float decodePixelMeasurement(global const ushort *data, global const short *lut1
   return (float)lut11to16[(x < 1 || 510 < x || col_idx > 352) ? 0 : ((data[data_idx0] >> upper_bytes) | (data[data_idx1] << lower_bytes)) & 2047];
 }
 
-float2 processMeasurementTriple(const float ab_multiplier_per_frq, const float p0, const float3 v, int *invalid)
-{
-  float3 p0vec = (float3)(p0 + PHASE_IN_RAD0, p0 + PHASE_IN_RAD1, p0 + PHASE_IN_RAD2);
-  float3 p0cos = cos(p0vec);
-  float3 p0sin = sin(-p0vec);
-
-  *invalid = *invalid && any(isequal(v, (float3)(32767.0f)));
-
-  return (float2)(dot(v, p0cos), dot(v, p0sin)) * ab_multiplier_per_frq;
-}
-
-void kernel processPixelStage1(global const short *lut11to16, global const float *z_table, global const float3 *p0_table, global const ushort *data,
-                               global float3 *a_out, global float3 *b_out, global float3 *n_out, global float *ir_out)
+void kernel processPixelStage1(global const short *lut11to16, global const float *z_table, global const float3 *p0_sin_table, global const float3 *p0_cos_table,
+                               global const ushort *data, global float3 *a_out, global float3 *b_out, global float3 *n_out, global float *ir_out)
 {
   const uint i = get_global_id(0);
 
   const uint x = i % 512;
   const uint y = i / 512;
 
-  const uint y_in = (423 - y);
+  const uint y_tmp = (423 - y);
+  const uint y_in = (y_tmp < 212 ? y_tmp + 212 : 423 - y_tmp);
 
-  const float zmultiplier = z_table[i];
-  int valid = (int)(0.0f < zmultiplier);
-  int saturatedX = valid;
-  int saturatedY = valid;
-  int saturatedZ = valid;
-  int3 invalid_pixel = (int3)((int)(!valid));
-  const float3 p0 = p0_table[i];
+  const int3 invalid = (int)(0.0f >= z_table[i]);
+  const float3 p0_sin = p0_sin_table[i];
+  const float3 p0_cos = p0_cos_table[i];
+
+  int3 invalid_pixel = (int3)(invalid);
 
   const float3 v0 = (float3)(decodePixelMeasurement(data, lut11to16, 0, x, y_in),
                              decodePixelMeasurement(data, lut11to16, 1, x, y_in),
                              decodePixelMeasurement(data, lut11to16, 2, x, y_in));
-  const float2 ab0 = processMeasurementTriple(AB_MULTIPLIER_PER_FRQ0, p0.x, v0, &saturatedX);
-
   const float3 v1 = (float3)(decodePixelMeasurement(data, lut11to16, 3, x, y_in),
                              decodePixelMeasurement(data, lut11to16, 4, x, y_in),
                              decodePixelMeasurement(data, lut11to16, 5, x, y_in));
-  const float2 ab1 = processMeasurementTriple(AB_MULTIPLIER_PER_FRQ1, p0.y, v1, &saturatedY);
-
   const float3 v2 = (float3)(decodePixelMeasurement(data, lut11to16, 6, x, y_in),
                              decodePixelMeasurement(data, lut11to16, 7, x, y_in),
                              decodePixelMeasurement(data, lut11to16, 8, x, y_in));
-  const float2 ab2 = processMeasurementTriple(AB_MULTIPLIER_PER_FRQ2, p0.z, v2, &saturatedZ);
 
-  float3 a = select((float3)(ab0.x, ab1.x, ab2.x), (float3)(0.0f), invalid_pixel);
-  float3 b = select((float3)(ab0.y, ab1.y, ab2.y), (float3)(0.0f), invalid_pixel);
+  float3 a = (float3)(dot(v0, PHASE_COS * p0_cos.x - PHASE_SIN * p0_sin.x),
+                      dot(v1, PHASE_COS * p0_cos.y - PHASE_SIN * p0_sin.y),
+                      dot(v2, PHASE_COS * p0_cos.z - PHASE_SIN * p0_sin.z)) * AB_MULTIPLIER_PER_FRQ;
+  float3 b = (float3)(dot(v0, PHASE_COS * p0_sin.x + PHASE_SIN * p0_cos.x),
+                      dot(v1, PHASE_COS * p0_sin.y + PHASE_SIN * p0_cos.y),
+                      dot(v2, PHASE_COS * p0_sin.z + PHASE_SIN * p0_cos.z)) * AB_MULTIPLIER_PER_FRQ;
+
+  a = select(a, (float3)(0.0f), invalid_pixel);
+  b = select(b, (float3)(0.0f), invalid_pixel);
   float3 n = sqrt(a * a + b * b);
 
-  int3 saturated = (int3)(saturatedX, saturatedY, saturatedZ);
-  a = select(a, (float3)(0.0f), saturated);
-  b = select(b, (float3)(0.0f), saturated);
+  int3 saturated = (int3)(any(isequal(v0, (float3)(32767.0f))),
+                          any(isequal(v1, (float3)(32767.0f))),
+                          any(isequal(v2, (float3)(32767.0f))));
 
-  a_out[i] = a;
-  b_out[i] = b;
+  a_out[i] = select(a, (float3)(0.0f), saturated);
+  b_out[i] = select(b, (float3)(0.0f), saturated);
   n_out[i] = n;
   ir_out[i] = min(dot(select(n, (float3)(65535.0f), saturated), (float3)(0.333333333f  * AB_MULTIPLIER * AB_OUTPUT_MULTIPLIER)), 65535.0f);
 }

--- a/src/opencl_depth_packet_processor.cpp
+++ b/src/opencl_depth_packet_processor.cpp
@@ -225,7 +225,7 @@ public:
   bool programInitialized;
   std::string sourceCode;
 
-#if LIBFREENECT2_WITH_PROFILING
+#ifdef LIBFREENECT2_WITH_PROFILING_CL
   std::vector<double> timings;
   int count;
 #endif
@@ -454,7 +454,7 @@ public:
 
   bool initBuffers()
   {
-#if LIBFREENECT2_WITH_PROFILING
+#ifdef LIBFREENECT2_WITH_PROFILING_CL
     count = 0;
     CHECK_CL_PARAM(queue = cl::CommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE, &err));
 #else
@@ -580,7 +580,7 @@ public:
     CHECK_CL_RETURN(eventReadIr.wait());
     CHECK_CL_RETURN(eventReadDepth.wait());
 
-#if LIBFREENECT2_WITH_PROFILING
+#ifdef LIBFREENECT2_WITH_PROFILING_CL
     if(count == 0)
     {
       timings.clear();


### PR DESCRIPTION
Which this PR includes:
- Custom Allocator and Frames for OpenCL using pinned memory
- Removed arrays for tables, instead data is directly written to the OpenCL buffers
- OpenCL buffers are now created only once on initialization
- Added definition to enable profiling for the OpenCL kernels
- Minor improvements for the first stage

With this improvements the OpenCL depth processor takes between 1.09 ms and 1.11 ms on my system, instead of ~2 ms. Most due to the pinned memory.