### PR TITLE
Issue reboot command on Mac OS X

### DIFF
--- a/src/libfreenect2.cpp
+++ b/src/libfreenect2.cpp
@@ -832,7 +832,13 @@ bool Freenect2DeviceImpl::close()
   /* This command actually reboots the device and makes it disappear for 3 seconds.
    * Protonect can restart instantly without it.
    */
-  //command_tx_.execute(ShutdownCommand(nextCommandSeq()), result);
+#ifdef __APPLE__
+  /* It is better to issue reboot command on Mac OS X.
+   * Refer issue #539 https://github.com/OpenKinect/libfreenect2/issues/539
+   */
+  command_tx_.execute(ShutdownCommand(nextCommandSeq()), result);
+  libfreenect2::this_thread::sleep_for(libfreenect2::chrono::milliseconds(4*1000));
+#endif
 
   if(pipeline_->getRgbPacketProcessor() != 0)
     pipeline_->getRgbPacketProcessor()->setFrameListener(0);


### PR DESCRIPTION
https://github.com/OpenKinect/libfreenect2/issues/539

tested 1000 times on Max OS X 10.11 El Capitan.

####  shutdown=0 / 1000  error=2

>#!/bin/bash
shutdown=0
error=0
shutdown_detected()
{
  echo "#### SHUTDOWN"
  shutdown=$(($shutdown + 1))
}
error_detected()
{
  echo "#### ERROR"
  error=$(($error + 1))
}
for i in {1..1000}; do
  ./bin/Protonect cl -frames 1 || error_detected
  sleep 1
  if ioreg -p IOUSB | grep -i xbox; then
    :
  else
    shutdown_detected
    sleep 5
  fi
  echo "####  shutdown=$shutdown / $i  error=$error"
done
