### PR TITLE
Reboot device

### DIFF
--- a/include/internal/libfreenect2/protocol/command_transaction.h
+++ b/include/internal/libfreenect2/protocol/command_transaction.h
@@ -47,6 +47,7 @@ public:
   CommandTransaction(libusb_device_handle *handle, int inbound_endpoint, int outbound_endpoint);
   ~CommandTransaction();
 
+  void setHandle(libusb_device_handle *handle);
   bool execute(const CommandBase& command, Result& result);
 private:
   libusb_device_handle *handle_;

--- a/include/internal/libfreenect2/protocol/usb_control.h
+++ b/include/internal/libfreenect2/protocol/usb_control.h
@@ -79,6 +79,7 @@ public:
     Error
   };
 
+  void setHandle(libusb_device_handle *handle);
   ResultCode getIrMaxIsoPacketSize(int &size);
 
   ResultCode setConfiguration();

--- a/include/internal/libfreenect2/time.h
+++ b/include/internal/libfreenect2/time.h
@@ -1,0 +1,106 @@
+/*
+ * This file is part of the OpenKinect Project. http://www.openkinect.org
+ *
+ * Copyright (c) 2015 individual OpenKinect contributors. See the CONTRIB file
+ * for details.
+ *
+ * This code is licensed to you under the terms of the Apache License, version
+ * 2.0, or, at your option, the terms of the GNU General Public License,
+ * version 2.0. See the APACHE20 and GPL2 files for the text of the licenses,
+ * or the following URLs:
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * If you redistribute this file in source form, modified or unmodified, you
+ * may:
+ *   1) Leave this header intact and distribute it under the same terms,
+ *      accompanying it with the APACHE20 and GPL20 files, or
+ *   2) Delete the Apache 2.0 clause and accompany it with the GPL2 file, or
+ *   3) Delete the GPL v2 clause and accompany it with the APACHE20 file
+ * In all cases you must keep the copyright notice intact and include a copy
+ * of the CONTRIB file.
+ *
+ * Binary distributions must follow the binary distribution requirements of
+ * either License.
+ */
+
+/** @file time.h Timer utility. */
+
+#ifdef LIBFREENECT2_WITH_CXX11_SUPPORT
+#include <chrono>
+#endif
+
+#ifdef LIBFREENECT2_WITH_OPENGL_SUPPORT
+#include <GLFW/glfw3.h>
+#endif
+
+namespace libfreenect2
+{
+
+class Timer
+{
+ public:
+  double duration;
+  size_t count;
+
+  Timer()
+  {
+#if defined(LIBFREENECT2_WITH_OPENGL_SUPPORT)
+    glfwInit();
+#endif
+    reset();
+  }
+
+  void reset()
+  {
+    duration = 0;
+    count = 0;
+  }
+
+#ifdef LIBFREENECT2_WITH_CXX11_SUPPORT
+  std::chrono::time_point<std::chrono::high_resolution_clock> time_start;
+
+  void start()
+  {
+    time_start = std::chrono::high_resolution_clock::now();
+  }
+
+  double elapsed()
+  {
+    auto time_diff = std::chrono::high_resolution_clock::now() - time_start;
+    double this_duration = std::chrono::duration_cast<std::chrono::duration<double>>(time_diff).count();
+    return this_duration;
+  }
+#elif defined(LIBFREENECT2_WITH_OPENGL_SUPPORT)
+  double time_start;
+
+  void start()
+  {
+    time_start = glfwGetTime();
+  }
+
+  double elapsed()
+  {
+    double this_duration = glfwGetTime() - time_start;
+    return this_duration;
+  }
+#else
+  void start()
+  {
+  }
+
+  double elapsed()
+  {
+    return 0;
+  }
+#endif
+  double stop()
+  {
+    double this_duration = elapsed();
+    duration += this_duration;
+    count++;
+    return this_duration;
+  }
+};
+
+} /* namespace libfreenect2 */

--- a/include/internal/libfreenect2/usb/transfer_pool.h
+++ b/include/internal/libfreenect2/usb/transfer_pool.h
@@ -45,6 +45,8 @@ public:
   TransferPool(libusb_device_handle *device_handle, unsigned char device_endpoint);
   virtual ~TransferPool();
 
+  void setHandle(libusb_device_handle* device_handle);
+
   void deallocate();
 
   void enableSubmission();

--- a/src/command_transaction.cpp
+++ b/src/command_transaction.cpp
@@ -47,6 +47,11 @@ CommandTransaction::CommandTransaction(libusb_device_handle *handle, int inbound
 
 CommandTransaction::~CommandTransaction() {}
 
+void CommandTransaction::setHandle(libusb_device_handle *handle)
+{
+  handle_ = handle;
+}
+
 bool CommandTransaction::execute(const CommandBase& command, Result& result)
 {
   result.resize(command.maxResponseLength());

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -27,6 +27,7 @@
 /** @file logging.cpp Logging message handler classes. */
 
 #include <libfreenect2/logging.h>
+#include <libfreenect2/time.h>
 #include <iostream>
 #include <cstdlib>
 #include <string>
@@ -37,14 +38,6 @@
 #include <numeric>
 #include <functional>
 #include <cmath>
-#endif
-
-#ifdef LIBFREENECT2_WITH_CXX11_SUPPORT
-#include <chrono>
-#endif
-
-#ifdef LIBFREENECT2_WITH_OPENGL_SUPPORT
-#include <GLFW/glfw3.h>
 #endif
 
 namespace libfreenect2
@@ -189,70 +182,6 @@ void setGlobalLogger(Logger *logger)
     delete userLogger_;
   userLogger_ = logger;
 }
-
-/** Timer for measuring performance. */
-class Timer
-{
- public:
-  double duration;
-  size_t count;
-
-  Timer()
-  {
-#if defined(LIBFREENECT2_WITH_OPENGL_SUPPORT)
-    glfwInit();
-#endif
-    reset();
-  }
-
-  void reset()
-  {
-    duration = 0;
-    count = 0;
-  }
-
-#ifdef LIBFREENECT2_WITH_CXX11_SUPPORT
-  std::chrono::time_point<std::chrono::high_resolution_clock> time_start;
-
-  void start()
-  {
-    time_start = std::chrono::high_resolution_clock::now();
-  }
-
-  double stop()
-  {
-    auto time_diff = std::chrono::high_resolution_clock::now() - time_start;
-    double this_duration = std::chrono::duration_cast<std::chrono::duration<double>>(time_diff).count();
-    duration += this_duration;
-    count++;
-    return this_duration;
-  }
-#elif defined(LIBFREENECT2_WITH_OPENGL_SUPPORT)
-  double time_start;
-
-  void start()
-  {
-    time_start = glfwGetTime();
-  }
-
-  double stop()
-  {
-    double this_duration = glfwGetTime() - time_start;
-    duration += this_duration;
-    count++;
-    return this_duration;
-  }
-#else
-  void start()
-  {
-  }
-
-  double stop()
-  {
-    return 0;
-  }
-#endif
-};
 
 class WithPerfLoggingImpl: public Timer
 {

--- a/src/transfer_pool.cpp
+++ b/src/transfer_pool.cpp
@@ -51,6 +51,11 @@ TransferPool::~TransferPool()
   deallocate();
 }
 
+void TransferPool::setHandle(libusb_device_handle* device_handle)
+{
+  device_handle_ = device_handle;
+}
+
 void TransferPool::enableSubmission()
 {
   enable_submit_ = true;

--- a/src/usb_control.cpp
+++ b/src/usb_control.cpp
@@ -189,6 +189,11 @@ UsbControl::~UsbControl()
 {
 }
 
+void UsbControl::setHandle(libusb_device_handle *handle)
+{
+    handle_ = handle;
+}
+
 #define CHECK_LIBUSB_RESULT(__CODE, __RESULT) if((__CODE = (__RESULT == LIBUSB_SUCCESS ? Success : Error)) == Error) LOG_ERROR
 #define WRITE_LIBUSB_ERROR(__RESULT) libusb_error_name(__RESULT) << " " << libusb_strerror((libusb_error)__RESULT) << ". Try debugging with environment variable: export LIBUSB_DEBUG=3 ."
 


### PR DESCRIPTION
Avoid being stuck in the status checking describing in
https://github.com/OpenKinect/libfreenect2/issues/539#issuecomment-189577849.

I tested that Protonect ran normally and reboot when timeout occurred in startStreams() on Mac OS X 10.11 and Ubuntu 14.04 (Jetson TK1) with these cmake configurations,
-DENABLE_CXX11=ON/OFF
-DENBELE_OPENGL=ON/OFF 