### PR TITLE
Protonect: Add timeout arg for waitForNewFrame()

### DIFF
--- a/examples/Protonect.cpp
+++ b/examples/Protonect.cpp
@@ -330,7 +330,11 @@ int main(int argc, char *argv[])
 /// [loop start]
   while(!protonect_shutdown && (framemax == (size_t)-1 || framecount < framemax))
   {
-    listener.waitForNewFrame(frames);
+    if (!listener.waitForNewFrame(frames, 10*1000)) // 10 sconds
+    {
+      std::cout << "timeout!" << std::endl;
+      return -1;
+    }
     libfreenect2::Frame *rgb = frames[libfreenect2::Frame::Color];
     libfreenect2::Frame *ir = frames[libfreenect2::Frame::Ir];
     libfreenect2::Frame *depth = frames[libfreenect2::Frame::Depth];


### PR DESCRIPTION
From #598 (Protonect ignores ^C)

Add timeout argument for waitForNewFrames() in the Protonect main loop. The Protonect exit if no frames come from the Kinect sensor for 10 seconds. This works only with c++11 option.

Tested on Mac OS X and ubuntu.

 * Mac OS X 10.11 with ENABLE_CXX11=ON
   * run "Protonect -frames 1" 40,000 times (about 100 hours)
   * Timeout in waitForNewFrames() occurred 26 times
 * Mac OS X 10.11 with ENABLE_CXX11=OFF
   * build and run "Protonect" normally
 * ubuntu 15.10 (Intel Mac) with ENABLE_CXX11=ON
   * build and run "Protonect -frames 1" 10,000 times. (no timeout occurred)
 * ubuntu 15.10 (Intel Mac) with ENABLE_CXX11=OFF
   * build and run "Protonect -frames 1" 10,000 times. (no timeout occurred)

There are some remaining issues.

ISSUE 1:
Protonect exit abnormally with "Abort trap: 6" in Freenect2DeviceImpl::~Freenect2DeviceImpl() when the timeout fired. The probability is 5/26. (i.e. 5/40,000)
I think we can ignore this issue because the probability is very low.

>& ./bin/Protonect -frames 1
Version: 0.2.0
Environment variables: LOGFILE=<protonect.log>
Usage: ./bin/Protonect [-gpu=<id>] [gl | cl | cuda | cpu] [<device serial>]
        [-noviewer] [-norgb | -nodepth] [-help] [-version]
        [-frames <number of frames to process>]
To pause and unpause: pkill -USR1 Protonect
[Info] [OpenCLDepthPacketProcessorImpl]  devices:
[Info] [OpenCLDepthPacketProcessorImpl]   0: Intel(R) Core(TM) i7-3770 CPU @ 3.40GHz (CPU)[Intel]
[Info] [OpenCLDepthPacketProcessorImpl]   1: GeForce GTX 675MX (GPU)[NVIDIA]
[Info] [OpenCLDepthPacketProcessorImpl] selected device: GeForce GTX 675MX (GPU)[NVIDIA]
[Info] [OpenCLDepthPacketProcessorImpl] building OpenCL program...
[Info] [OpenCLDepthPacketProcessorImpl] OpenCL program built successfully
[Info] [Freenect2Impl] enumerating devices...
[Info] [Freenect2Impl] 13 usb devices connected
[Info] [Freenect2Impl] found valid Kinect v2 @20:16 with serial 005697142447
[Info] [Freenect2Impl] found 1 devices
[Info] [Freenect2DeviceImpl] opening...
[Info] [Freenect2DeviceImpl] opened
[Info] [Freenect2DeviceImpl] starting...
[Debug] [Freenect2DeviceImpl] status 0x090000: 1024
[Debug] [Freenect2DeviceImpl] status 0x090000: 9729
[Debug] [Freenect2DeviceImpl] status 0x090000: 9731
[Info] [Freenect2DeviceImpl] submitting rgb transfers...
[Info] [Freenect2DeviceImpl] submitting depth transfers...
[Info] [Freenect2DeviceImpl] started
device serial: 005697142447
device firmware: 4.0.3912.0
[Info] [VTRgbPacketProcessor] avg. time: 16.7513ms -> ~59.6968Hz
[Info] [VTRgbPacketProcessor] avg. time: 16.6441ms -> ~60.0814Hz
timeout!
[Info] [Freenect2DeviceImpl] closing...
[Info] [Freenect2DeviceImpl] stopping...
[Info] [Freenect2DeviceImpl] canceling rgb transfers...
libc++abi.dylib: terminating with uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument
82471 Abort trap: 6           ./bin/Protonect cl -frames 1

ISSUE2:
Protonect message end with "status 0x090000: 1024" and does not show the window and images. The probability is 4,586/40,000. I will report this issue later separately.

>& ./bin/Protonect -frames 1
Version: 0.2.0
Environment variables: LOGFILE=<protonect.log>
Usage: ./bin/Protonect [-gpu=<id>] [gl | cl | cuda | cpu] [<device serial>]
        [-noviewer] [-norgb | -nodepth] [-help] [-version]
        [-frames <number of frames to process>]
To pause and unpause: pkill -USR1 Protonect
[Info] [OpenCLDepthPacketProcessorImpl]  devices:
[Info] [OpenCLDepthPacketProcessorImpl]   0: Intel(R) Core(TM) i7-3770 CPU @ 3.40GHz (CPU)[Intel]
[Info] [OpenCLDepthPacketProcessorImpl]   1: GeForce GTX 675MX (GPU)[NVIDIA]
[Info] [OpenCLDepthPacketProcessorImpl] selected device: GeForce GTX 675MX (GPU)[NVIDIA]
[Info] [OpenCLDepthPacketProcessorImpl] building OpenCL program...
[Info] [OpenCLDepthPacketProcessorImpl] OpenCL program built successfully
[Info] [Freenect2Impl] enumerating devices...
[Info] [Freenect2Impl] 13 usb devices connected
[Info] [Freenect2Impl] found valid Kinect v2 @20:31 with serial 005697142447
[Info] [Freenect2Impl] found 1 devices
[Info] [Freenect2DeviceImpl] opening...
[Info] [Freenect2DeviceImpl] opened
[Info] [Freenect2DeviceImpl] starting...
[Debug] [Freenect2DeviceImpl] status 0x090000: 1024