### PR TITLE
Implement non-default pipeline selection from OpenNI2 side.

### DIFF
--- a/src/libfreenect2.cpp
+++ b/src/libfreenect2.cpp
@@ -900,15 +900,29 @@ bool Freenect2DeviceImpl::close()
 
 PacketPipeline *createDefaultPacketPipeline()
 {
+  const char *pipeline_type_env;
+  // GL, CL, CUDA, CPU
+  pipeline_type_env = std::getenv("LIBFREENECT2_PIPELINE");
+  std::string pipeline_type;
+
+  if (pipeline_type_env)
+    pipeline_type = std::string(pipeline_type_env);
+
 #if defined(LIBFREENECT2_WITH_OPENGL_SUPPORT)
-  return new OpenGLPacketPipeline();
-#elif defined(LIBFREENECT2_WITH_CUDA_SUPPORT)
-  return new CudaPacketPipeline();
-#elif defined(LIBFREENECT2_WITH_OPENCL_SUPPORT)
-  return new OpenCLPacketPipeline();
-#else
-  return new CpuPacketPipeline();
+  if (pipeline_type == "GL")
+    return new OpenGLPacketPipeline();
 #endif
+#if defined(LIBFREENECT2_WITH_CUDA_SUPPORT)
+  if (pipeline_type == "CUDA")
+    return new CudaPacketPipeline();
+#endif
+#if defined(LIBFREENECT2_WITH_OPENCL_SUPPORT)
+  if (pipeline_type == "CL")
+    return new OpenCLPacketPipeline();
+#endif
+
+  // pipeline_type == "CPU" would be the default
+  return new CpuPacketPipeline();
 }
 
 Freenect2::Freenect2(void *usb_context) :

--- a/src/openni2/DeviceDriver.cpp
+++ b/src/openni2/DeviceDriver.cpp
@@ -500,7 +500,9 @@ namespace Freenect2Driver
             WriteMessage("Opening device " + std::string(uri));
             int id = uri_to_devid(iter->first.uri);
             DeviceImpl* device = new DeviceImpl(id);
-            device->setFreenect2Device(freenect2.openDevice(id)); // XXX, detault pipeline // const PacketPipeline *factory);
+            // The LIBFREENECT2_PIPELINE variable allows to select
+            // the non-default pipeline
+            device->setFreenect2Device(freenect2.openDevice(id));
             device->setConfigStrings(config);
             iter->second = device;
             return device;

--- a/src/openni2/DeviceDriver.cpp
+++ b/src/openni2/DeviceDriver.cpp
@@ -500,43 +500,7 @@ namespace Freenect2Driver
             WriteMessage("Opening device " + std::string(uri));
             int id = uri_to_devid(iter->first.uri);
             DeviceImpl* device = new DeviceImpl(id);
-
-			const char *pipeline_type_env;
-			// GL, CL, CUDA, CPU
-			pipeline_type_env = std::getenv("LIBFREENECT2_NITE_PIPELINE_TYPE");
-			std::string pipeline_type;
-
-			if (pipeline_type_env)
-			{
-				pipeline_type = std::string(pipeline_type_env);
-			}
-
-			libfreenect2::PacketPipeline* pipeline = NULL;
-
-#if defined(LIBFREENECT2_WITH_OPENGL_SUPPORT)
-			if (pipeline_type == "GL")
-				pipeline = new libfreenect2::OpenGLPacketPipeline();
-#elif defined(LIBFREENECT2_WITH_CUDA_SUPPORT)
-			if (pipeline_type == "CUDA")
-				pipeline = new libfreenect2::CudaPacketPipeline();
-#elif defined(LIBFREENECT2_WITH_OPENCL_SUPPORT)
-			if (pipeline_type == "CL")
-				pipeline = new libfreenect2::OpenCLPacketPipeline();
-#else
-			if (pipeline_type == "CPU")
-				pipeline = new libfreenect2::CpuPacketPipeline();
-#endif
-
-			// Fallback on whatever the default pipeline maybe if none were selected above
-			if (!pipeline)
-			{
-				device->setFreenect2Device(freenect2.openDevice(id));
-			}
-			else
-			{
-				device->setFreenect2Device(freenect2.openDevice(id, pipeline));
-			}
-
+            device->setFreenect2Device(freenect2.openDevice(id)); // XXX, detault pipeline // const PacketPipeline *factory);
             device->setConfigStrings(config);
             iter->second = device;
             return device;


### PR DESCRIPTION
This PM implements a way to select non-default pipeline when using OpenNI2 driver with NiTE samples. This is done via an environment variable `LIBFREENECT2_NITE_PIPELINE_TYPE` that takes values `GL`, `CL`,  `CUDA`, and `CPU`. If none are selected, the default pipeline is selected as before. The change can be done at run-time. I needed that feature being stuck for a while with default TurboJPEG and GL stuff. Please consider for inclusion.