### PR TITLE
Avoid overriding the PKG_CONFIG_PATH environment variable

### DIFF
--- a/cmake_modules/FindLibUSB.cmake
+++ b/cmake_modules/FindLibUSB.cmake
@@ -9,7 +9,7 @@
 
 IF(PKG_CONFIG_FOUND)
   IF(DEPENDS_DIR) #Otherwise use System pkg-config path
-    SET(ENV{PKG_CONFIG_PATH} "${DEPENDS_DIR}/libusb/lib/pkgconfig")
+    SET(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${DEPENDS_DIR}/libusb/lib/pkgconfig")
   ENDIF()
   SET(MODULE "libusb-1.0")
   IF(CMAKE_SYSTEM_NAME MATCHES "Linux")


### PR DESCRIPTION
A very small change to append the local path to the current PKG_CONFIG_PATH on the system.
Without this change, if libusb is on the system but not in the default paths, cmake won't find it even if PKG_CONFIG_PATH is correctly set.

I've only tested it on cmake 3.0, and maybe [this improvement on cmake 3.1](http://public.kitware.com/Bug/view.php?id=12926) solves the overriding...?
But anyway, append paths to the system's PKG_CONFIG_PATH seems better than overrinding it.
