### PR TITLE
Fix OpenNI2 enumeration softlocking sensors

### DIFF
--- a/src/openni2/DeviceDriver.cpp
+++ b/src/openni2/DeviceDriver.cpp
@@ -429,7 +429,8 @@ namespace Freenect2Driver
     OniStatus initialize(oni::driver::DeviceConnectedCallback connectedCallback, oni::driver::DeviceDisconnectedCallback disconnectedCallback, oni::driver::DeviceStateChangedCallback deviceStateChangedCallback, void* pCookie)
     {
       DriverBase::initialize(connectedCallback, disconnectedCallback, deviceStateChangedCallback, pCookie);
-      for (int i = 0; i < freenect2.enumerateDevices(); i++)
+      int devices_found = freenect2.enumerateDevices();
+      for (int i = 0; i < devices_found; i++)
       {
         std::string uri = devid_to_uri(i);
         const char* modes_c[] = {


### PR DESCRIPTION
In the OpenNI2 driver the initialization function (after calling `OpenNI::initialize()` in the client application), the driver will go to DeviceDriver.cpp `Driver::initialize()`. This function has a loop  `for int i = 0; i < freenect2.enumerateDevices(); i++) { ... }`. This loop will cause all Kinect 2 USB devices to be unreachable until Windows restart is performed on some Windows builds. This happens, for some reason, because the loop's end condition, `freenect2.enumerateDevices()`, is called on every loop. Something in this seems to utterly break libusb / UsbDK. The fix is to do the enumeration only once and save the result. There is probably some bigger reason as to why this happens, but I wasn't able to debug libusb / UsbDK to figure out the real culprit.

When the enumeration is done every loop, the program will freeze at the enumeration call until after about 3 minutes this is printed:
```
[Error] [Freenect2Impl] failed to open Kinect v2: @4:2 LIBUSB_ERROR_OTHER Other error"
```

After this error happens, on attempting to use the sensor again with Protonect without OpenNI2, the device cannot be opened:
```
[Info] [Freenect2Impl] enumerating devices...
[Info] [Freenect2Impl] 8 usb devices connected
Driver file operation error. DeviceIoControl failed (Cannot create a file when that file already exists.  Error code = 183)
libusb: error [usbdk_open] Redirector startup failed
[Error] [Freenect2Impl] failed to open Kinect v2: @4:2 LIBUSB_ERROR_OTHER Other error
[Info] [Freenect2Impl] found 0 devices
no device connected!
```

I tried using LIBUSB_DEBUG=3 (in the Windows env vars), but it didn't seem to do anything.

I've attempted unplugging the sensor, moving it in a different USB3 controller (I have 3 separate USB 3 controllers on my motherboard / external card) and manually disabling the sensor via Device Manager. None of these actions seem to free the device. Interestingly, if I unplug the sensor and attempt to use Protonect, the sensor is still found and the same error as above is printed. The only ways I've found to circumvent this problem are restarting Windows or uninstalling + reinstalling UsbDK runtime. Plugging in a new Kinect 2 device works, until the same problem happens for it.

I'm not seeing this when building with MSVC 2013 64-bit, while using MSVC 2010 64-bit seems to cause the problem. I'm on Windows 8.1. I haven't tested if this happens on OS X or Linux.
