### PR TITLE
implemented VideoStream::convertDepthToColorCoordinates (openni2)

### DIFF
--- a/src/openni2/Registration.cpp
+++ b/src/openni2/Registration.cpp
@@ -46,7 +46,8 @@ void Registration::depthFrame(libfreenect2::Frame* frame) {
 }
 
 
-static libfreenect2::Registration* make_registration(libfreenect2::Freenect2Device* dev) {
+static libfreenect2::Registration* make_registration(libfreenect2::Freenect2Device* dev)
+{
   libfreenect2::Freenect2Device::ColorCameraParams colCamParams = dev->getColorCameraParams();
   libfreenect2::Freenect2Device::IrCameraParams irCamParams = dev->getIrCameraParams();
   {
@@ -78,7 +79,8 @@ void Registration::setEnable(bool enable) { enabled = enable; }
 
 bool Registration::isEnabled() { return enabled; }
 
-void Registration::depthToColor(int dx, int dy, float dz, float& cx, float& cy) {
+void Registration::depthToColor(int dx, int dy, float dz, float& cx, float& cy)
+{
 
   if(!reg) {
 	reg = make_registration(dev);

--- a/src/openni2/Registration.cpp
+++ b/src/openni2/Registration.cpp
@@ -45,22 +45,28 @@ void Registration::depthFrame(libfreenect2::Frame* frame) {
   lastDepthFrame = frame;
 }
 
+
+static libfreenect2::Registration* make_registration(libfreenect2::Freenect2Device* dev) {
+  libfreenect2::Freenect2Device::ColorCameraParams colCamParams = dev->getColorCameraParams();
+  libfreenect2::Freenect2Device::IrCameraParams irCamParams = dev->getIrCameraParams();
+  {
+	libfreenect2::Freenect2Device::ColorCameraParams cp = colCamParams;
+	std::cout << "fx=" << cp.fx << ",fy=" << cp.fy <<
+	  ",cx=" << cp.cx << ",cy=" << cp.cy << std::endl;
+	libfreenect2::Freenect2Device::IrCameraParams ip = irCamParams;
+	std::cout << "fx=" << ip.fx << ",fy=" << ip.fy <<
+	  ",ix=" << ip.cx << ",iy=" << ip.cy <<
+	  ",k1=" << ip.k1 << ",k2=" << ip.k2 << ",k3=" << ip.k3 <<
+	  ",p1=" << ip.p1 << ",p2=" << ip.p2 << std::endl;
+  }
+  
+  return new libfreenect2::Registration(irCamParams, colCamParams);
+}
+
 void Registration::colorFrameRGB888(libfreenect2::Frame* colorFrame, libfreenect2::Frame* registeredFrame) 
 {
   if (!reg) {
-    libfreenect2::Freenect2Device::ColorCameraParams colCamParams = dev->getColorCameraParams();
-    libfreenect2::Freenect2Device::IrCameraParams irCamParams = dev->getIrCameraParams();
-	{
-		libfreenect2::Freenect2Device::ColorCameraParams cp = colCamParams;
-		std::cout << "fx=" << cp.fx << ",fy=" << cp.fy <<
-			",cx=" << cp.cx << ",cy=" << cp.cy << std::endl;
-		libfreenect2::Freenect2Device::IrCameraParams ip = irCamParams;
-		std::cout << "fx=" << ip.fx << ",fy=" << ip.fy <<
-			",ix=" << ip.cx << ",iy=" << ip.cy <<
-			",k1=" << ip.k1 << ",k2=" << ip.k2 << ",k3=" << ip.k3 <<
-			",p1=" << ip.p1 << ",p2=" << ip.p2 << std::endl;
-	}
-    reg = new libfreenect2::Registration(irCamParams, colCamParams);
+	reg = make_registration(dev);
   }
   
   libfreenect2::Frame undistorted(lastDepthFrame->width, lastDepthFrame->height, lastDepthFrame->bytes_per_pixel);
@@ -71,3 +77,12 @@ void Registration::colorFrameRGB888(libfreenect2::Frame* colorFrame, libfreenect
 void Registration::setEnable(bool enable) { enabled = enable; }
 
 bool Registration::isEnabled() { return enabled; }
+
+void Registration::depthToColor(int dx, int dy, float dz, float& cx, float& cy) {
+
+  if(!reg) {
+	reg = make_registration(dev);
+  }
+  
+  reg->apply(dx, dy, dz, cx, cy);
+}

--- a/src/openni2/Registration.hpp
+++ b/src/openni2/Registration.hpp
@@ -42,7 +42,11 @@ namespace Freenect2Driver {
 
     void depthFrame(libfreenect2::Frame* frame);
     void colorFrameRGB888(libfreenect2::Frame* srcFrame, libfreenect2::Frame* dstFrame);
+	
     void setEnable(bool enable = true);
     bool isEnabled();
+
+	void depthToColor(int dx, int dy, float dz, float& cx, float& cy);
+	
   };
 }

--- a/src/openni2/VideoStream.cpp
+++ b/src/openni2/VideoStream.cpp
@@ -273,7 +273,23 @@ OniStatus VideoStream::setProperty(int propertyId, const void* data, int dataSiz
 }
 
 
-/* todo : from StreamBase
-virtual OniStatus convertDepthToColorCoordinates(StreamBase* colorStream, int depthX, int depthY, OniDepthPixel depthZ, int* pColorX, int* pColorY) { return ONI_STATUS_NOT_SUPPORTED; }
-*/
+
+
+
+OniStatus VideoStream::convertDepthToColorCoordinates(StreamBase* colorStream,
+													  int depthX, int depthY, OniDepthPixel depthZ,
+													  int* pColorX, int* pColorY)
+{
+  if(!reg) return ONI_STATUS_NOT_SUPPORTED;
+  
+  float cx, cy;
+  const float dz = depthZ;
+  reg->depthToColor(depthX, depthY, dz, cx, cy);
+  
+  *pColorX = cx;
+  *pColorY = cy;
+  
+  return ONI_STATUS_OK;
+}
+
 }

--- a/src/openni2/VideoStream.cpp
+++ b/src/openni2/VideoStream.cpp
@@ -276,9 +276,7 @@ OniStatus VideoStream::setProperty(int propertyId, const void* data, int dataSiz
 
 
 
-OniStatus VideoStream::convertDepthToColorCoordinates(StreamBase* colorStream,
-													  int depthX, int depthY, OniDepthPixel depthZ,
-													  int* pColorX, int* pColorY)
+OniStatus VideoStream::convertDepthToColorCoordinates(StreamBase* colorStream, int depthX, int depthY, OniDepthPixel depthZ, int* pColorX, int* pColorY)
 {
   if(!reg) return ONI_STATUS_NOT_SUPPORTED;
   

--- a/src/openni2/VideoStream.hpp
+++ b/src/openni2/VideoStream.hpp
@@ -84,9 +84,7 @@ namespace Freenect2Driver
     virtual OniStatus getProperty(int propertyId, void* data, int* pDataSize);
     virtual OniStatus setProperty(int propertyId, const void* data, int dataSize);
 
-    virtual OniStatus convertDepthToColorCoordinates(StreamBase* colorStream,
-													 int depthX, int depthY, OniDepthPixel depthZ,
-													 int* pColorX, int* pColorY);
+    virtual OniStatus convertDepthToColorCoordinates(StreamBase* colorStream, int depthX, int depthY, OniDepthPixel depthZ, int* pColorX, int* pColorY);
 
   };
 }

--- a/src/openni2/VideoStream.hpp
+++ b/src/openni2/VideoStream.hpp
@@ -84,8 +84,9 @@ namespace Freenect2Driver
     virtual OniStatus getProperty(int propertyId, void* data, int* pDataSize);
     virtual OniStatus setProperty(int propertyId, const void* data, int dataSize);
 
-    /* todo : from StreamBase
-    virtual OniStatus convertDepthToColorCoordinates(StreamBase* colorStream, int depthX, int depthY, OniDepthPixel depthZ, int* pColorX, int* pColorY) { return ONI_STATUS_NOT_SUPPORTED; }
-    */
+    virtual OniStatus convertDepthToColorCoordinates(StreamBase* colorStream,
+													 int depthX, int depthY, OniDepthPixel depthZ,
+													 int* pColorX, int* pColorY);
+
   };
 }


### PR DESCRIPTION
Hello,

I stumbled upon an unimplemented method in openni2 driver when trying to convert between depth/color coordinates: `VideoStream::convertDepthToColorCoordinates`. So here is a fix.

The PR is pretty straightforward: 
- exposed `libfreenect2::Registration::apply` in `Freenect2Driver::Registration`, 
- adapted what's needed in `VideoStream::convertDepthToColorCoordinates`.

It seems working for my needs and I have NiTE2 skeleton tracking on top of color stream (yay!), but since this is my first time hacking on `libfreenect2` please let me know if I did something silly.

Best regards, 