### PR TITLE
Disable default copy and assignment constructors

### DIFF
--- a/include/libfreenect2/frame_listener_impl.h
+++ b/include/libfreenect2/frame_listener_impl.h
@@ -75,6 +75,10 @@ public:
   virtual bool onNewFrame(Frame::Type type, Frame *frame);
 private:
   SyncMultiFrameListenerImpl *impl_;
+
+  /* Disable copy and assignment constructors */
+  SyncMultiFrameListener(const SyncMultiFrameListener&);
+  SyncMultiFrameListener& operator=(const SyncMultiFrameListener&);
 };
 
 ///@}

--- a/include/libfreenect2/libfreenect2.hpp
+++ b/include/libfreenect2/libfreenect2.hpp
@@ -268,6 +268,10 @@ public:
   Freenect2Device *openDefaultDevice(const PacketPipeline *factory);
 private:
   Freenect2Impl *impl_;
+
+  /* Disable copy and assignment constructors */
+  Freenect2(const Freenect2&);
+  Freenect2& operator=(const Freenect2&);
 };
 
 ///@}

--- a/include/libfreenect2/registration.h
+++ b/include/libfreenect2/registration.h
@@ -116,6 +116,10 @@ public:
 
 private:
   RegistrationImpl *impl_;
+
+  /* Disable copy and assignment constructors */
+  Registration(const Registration&);
+  Registration& operator=(const Registration&);
 };
 
 } /* namespace libfreenect2 */


### PR DESCRIPTION
To prevent locks from being copied.

See #677.