### PR TITLE
Changed MIN GL Version from 3 to 2

### DIFF
--- a/examples/viewer.cpp
+++ b/examples/viewer.cpp
@@ -26,7 +26,7 @@ void Viewer::initialize()
     glfwDefaultWindowHints();
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
 #ifdef __APPLE__
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 #else


### PR DESCRIPTION
changed glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3); to glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2); in order to get compatibility with older opengl versions.