### PR TITLE
add osx library path for brew install

### DIFF
--- a/cmake_modules/FindOpenNI2.cmake
+++ b/cmake_modules/FindOpenNI2.cmake
@@ -35,6 +35,7 @@ FIND_LIBRARY(OpenNI2_LIBRARY
     "/opt/local/lib"
     "/usr/lib"
     "/usr/local/lib"
+    "/usr/local/lib/ni2"
     ENV OPENNI2_REDIST
     ENV PROGRAMFILES
     ENV ProgramW6432


### PR DESCRIPTION
Fixes #917.

It seems the `openni2` brew package installs to [`/usr/local/lib/ni2`](https://github.com/Homebrew/homebrew-science/blob/58e8834dd8e916f51a26e96de1573018a82914ca/openni2.rb#L41).  The driver libraries are in `/usr/local/lib/ni2/OpenNI2/Drivers`, but I don't think that matters.