### PR TITLE
Freenect2ReplayDevice: API aligned with Freenect2Device

### DIFF
--- a/include/libfreenect2/libfreenect2.hpp
+++ b/include/libfreenect2/libfreenect2.hpp
@@ -34,10 +34,6 @@
 #include <libfreenect2/packet_pipeline.h>
 #include <string>
 
-namespace tthread {
-  class thread;
-}
-
 namespace libfreenect2
 {
 
@@ -276,49 +272,6 @@ private:
   /* Disable copy and assignment constructors */
   Freenect2(const Freenect2&);
   Freenect2& operator=(const Freenect2&);
-};
-
-class LIBFREENECT2_API Freenect2ReplayDevice: public Freenect2Device
-{
-public:
-  Freenect2ReplayDevice(char* directory, PacketPipeline* pipeline);
- 
-  virtual std::string getSerialNumber();
-  virtual std::string getFirmwareVersion();
-
-  virtual ColorCameraParams getColorCameraParams();
-  virtual IrCameraParams getIrCameraParams();
-
-  virtual void setColorCameraParams(const ColorCameraParams &params);
-  virtual void setIrCameraParams(const IrCameraParams &params);
-
-  void setColorFrameListener(FrameListener* listener);
-  void setIrAndDepthFrameListener(FrameListener* listener);
-
-  virtual void setConfiguration(const Config &config);
-  
-  void loadP0Tables(unsigned char* buffer, size_t buffer_length);
-  void loadXZTables(const float *xtable, const float *ztable);
-  void loadLookupTable(const short *lut);
-
-  bool processRawFrame(Frame::Type type, Frame* frame);  
-
-  virtual bool start();
-  virtual bool startStreams(bool rgb, bool depth);
-  virtual bool stop();
-  virtual bool run();
-
-protected:
-  void processRgbFrame(Frame* frame);
-  void processDepthFrame(Frame* frame);
-
-private:
-  PacketPipeline* pipeline_;
-  char* directory_;
-  tthread::thread* t_;
-  bool running_;
-  Freenect2Device::IrCameraParams ir_camera_params_;
-  Freenect2Device::ColorCameraParams rgb_camera_params_;
 };
 
 ///@}

--- a/include/libfreenect2/libfreenect2.hpp
+++ b/include/libfreenect2/libfreenect2.hpp
@@ -295,6 +295,8 @@ public:
   void setColorFrameListener(FrameListener* listener);
   void setIrAndDepthFrameListener(FrameListener* listener);
 
+  virtual void setConfiguration(const Config &config);
+  
   void loadP0Tables(unsigned char* buffer, size_t buffer_length);
   void loadXZTables(const float *xtable, const float *ztable);
   void loadLookupTable(const short *lut);
@@ -302,6 +304,7 @@ public:
   bool processRawFrame(Frame::Type type, Frame* frame);  
 
   virtual bool start();
+  virtual bool startStreams(bool rgb, bool depth);
   virtual bool stop();
   virtual bool run();
 

--- a/include/libfreenect2/libfreenect2.hpp
+++ b/include/libfreenect2/libfreenect2.hpp
@@ -278,32 +278,44 @@ private:
   Freenect2& operator=(const Freenect2&);
 };
 
-class LIBFREENECT2_API Freenect2ReplayDevice: public Freenect2Device {
- public:
+class LIBFREENECT2_API Freenect2ReplayDevice: public Freenect2Device
+{
+public:
   Freenect2ReplayDevice(char* directory, PacketPipeline* pipeline);
  
+  virtual std::string getSerialNumber();
+  virtual std::string getFirmwareVersion();
+
+  virtual ColorCameraParams getColorCameraParams();
+  virtual IrCameraParams getIrCameraParams();
+
+  virtual void setColorCameraParams(const ColorCameraParams &params);
+  virtual void setIrCameraParams(const IrCameraParams &params);
+
   void setColorFrameListener(FrameListener* listener);
   void setIrAndDepthFrameListener(FrameListener* listener);
-
 
   void loadP0Tables(unsigned char* buffer, size_t buffer_length);
   void loadXZTables(const float *xtable, const float *ztable);
   void loadLookupTable(const short *lut);
 
   bool processRawFrame(Frame::Type type, Frame* frame);  
-  bool start();
-  bool stop();
-  bool run();
 
- protected:
+  virtual bool start();
+  virtual bool stop();
+  virtual bool run();
+
+protected:
   void processRgbFrame(Frame* frame);
   void processDepthFrame(Frame* frame);
 
- private:
+private:
   PacketPipeline* pipeline_;
   char* directory_;
   tthread::thread* t_;
   bool running_;
+  Freenect2Device::IrCameraParams ir_camera_params_;
+  Freenect2Device::ColorCameraParams rgb_camera_params_;
 };
 
 ///@}

--- a/include/libfreenect2/libfreenect2.hpp
+++ b/include/libfreenect2/libfreenect2.hpp
@@ -278,7 +278,7 @@ private:
   Freenect2& operator=(const Freenect2&);
 };
 
-class LIBFREENECT2_API Freenect2ReplayDevice {
+class LIBFREENECT2_API Freenect2ReplayDevice: public Freenect2Device {
  public:
   Freenect2ReplayDevice(char* directory, PacketPipeline* pipeline);
  
@@ -291,9 +291,9 @@ class LIBFREENECT2_API Freenect2ReplayDevice {
   void loadLookupTable(const short *lut);
 
   bool processRawFrame(Frame::Type type, Frame* frame);  
-  void start();
-  void stop();
-  void run();
+  bool start();
+  bool stop();
+  bool run();
 
  protected:
   void processRgbFrame(Frame* frame);

--- a/include/libfreenect2/libfreenect2.hpp
+++ b/include/libfreenect2/libfreenect2.hpp
@@ -34,6 +34,10 @@
 #include <libfreenect2/packet_pipeline.h>
 #include <string>
 
+namespace tthread {
+  class thread;
+}
+
 namespace libfreenect2
 {
 
@@ -272,6 +276,34 @@ private:
   /* Disable copy and assignment constructors */
   Freenect2(const Freenect2&);
   Freenect2& operator=(const Freenect2&);
+};
+
+class LIBFREENECT2_API Freenect2ReplayDevice {
+ public:
+  Freenect2ReplayDevice(char* directory, PacketPipeline* pipeline);
+ 
+  void setColorFrameListener(FrameListener* listener);
+  void setIrAndDepthFrameListener(FrameListener* listener);
+
+
+  void loadP0Tables(unsigned char* buffer, size_t buffer_length);
+  void loadXZTables(const float *xtable, const float *ztable);
+  void loadLookupTable(const short *lut);
+
+  bool processRawFrame(Frame::Type type, Frame* frame);  
+  void start();
+  void stop();
+  void run();
+
+ protected:
+  void processRgbFrame(Frame* frame);
+  void processDepthFrame(Frame* frame);
+
+ private:
+  PacketPipeline* pipeline_;
+  char* directory_;
+  tthread::thread* t_;
+  bool running_;
 };
 
 ///@}

--- a/include/libfreenect2/libfreenect2.hpp
+++ b/include/libfreenect2/libfreenect2.hpp
@@ -302,12 +302,19 @@ public:
   std::string getDefaultDeviceSerialNumber();
 
   /** Open device by a collection of stored frame filenames with default pipeline.
+   * See filename format below.
    * @param frame_filenames A list of filenames for stored frames.
    * @return New device object, or NULL on failure
    */
   Freenect2Device *openDevice(const std::vector<std::string>& frame_filenames);
 
   /** Open device by a collection of stored frame filenames with the specified pipeline.
+   * File names non-compliant with the filename format will be skipped.
+   * Filename format: <prefix>_<timestamp>_<sequence>.<suffix>
+   *  <prefix> - a string of the filename, anything
+   *  <timestamp> -- packet timestamp as in pipeline packets
+   *  <sequence> -- frame sequence number in the packet
+   *  <suffix> -- .depth, .jpg, or .jpeg (case insensitive) 
    * @param frame_filenames A list of filenames for stored frames.
    * @param factory New PacketPipeline instance. This is always automatically freed.
    * @return New device object, or NULL on failure

--- a/include/libfreenect2/libfreenect2.hpp
+++ b/include/libfreenect2/libfreenect2.hpp
@@ -33,6 +33,7 @@
 #include <libfreenect2/frame_listener.hpp>
 #include <libfreenect2/packet_pipeline.h>
 #include <string>
+#include <vector>
 
 namespace libfreenect2
 {
@@ -272,6 +273,61 @@ private:
   /* Disable copy and assignment constructors */
   Freenect2(const Freenect2&);
   Freenect2& operator=(const Freenect2&);
+};
+
+class Freenect2ReplayDevice;
+
+/**
+ * Library context to create and open replay devices.
+ *
+ * You openDevice() and control the device with returned Freenect2ReplayDevice object.
+ *
+ * You may open devices with custom PacketPipeline.
+ * After passing a PacketPipeline object to libfreenect2 do not use or free the object,
+ * libfreenect2 will take care. If openDevice() fails the PacketPipeline object will get
+ * deleted. A new PacketPipeline object has to be created each time a device is opened.
+ */
+class LIBFREENECT2_API Freenect2Replay
+{
+public:
+  /**
+   * Creates the context.
+   */
+  Freenect2Replay();
+  virtual ~Freenect2Replay();
+
+  /**
+   * @return Replay device serial number.
+   */
+  std::string getDefaultDeviceSerialNumber();
+
+  /** Open device by a collection of stored frame filenames with default pipeline.
+   * @param frame_filenames A list of filenames for stored frames.
+   * @return New device object, or NULL on failure
+   */
+  Freenect2Device *openDevice(const std::vector<std::string>& frame_filenames);
+
+  /** Open device by a collection of stored frame filenames with the specified pipeline.
+   * @param frame_filenames A list of filenames for stored frames.
+   * @param factory New PacketPipeline instance. This is always automatically freed.
+   * @return New device object, or NULL on failure
+   */
+  Freenect2Device *openDevice(const std::vector<std::string>& frame_filenames, const PacketPipeline *factory);
+
+private:
+  typedef std::vector<Freenect2ReplayDevice*> DeviceVector;
+  DeviceVector devices_;
+
+  bool initialized;
+
+  void addDevice(Freenect2ReplayDevice *device);
+  void removeDevice(Freenect2ReplayDevice *device);
+  void clearDevices();
+  int getNumDevices();
+  
+  /* Disable copy and assignment constructors */
+  Freenect2Replay(const Freenect2Replay&);
+  Freenect2Replay& operator=(const Freenect2Replay&);
 };
 
 ///@}

--- a/src/libfreenect2.cpp
+++ b/src/libfreenect2.cpp
@@ -1194,16 +1194,18 @@ void runner (void* arg) {
   static_cast<Freenect2ReplayDevice*>(arg)->run();
 }
 
-void Freenect2ReplayDevice::start() {
+bool Freenect2ReplayDevice::start() {
   running_ = true;
   t_ = new thread(runner, this);
+  return running_;
 }
 
-void Freenect2ReplayDevice::stop() {
+bool Freenect2ReplayDevice::stop() {
   running_ = false;
   t_->join();
   delete t_;
   t_ = NULL;
+  return !running_;
 }
 
 bool hasSuffix(const std::string& str, const std::string& suffix) {
@@ -1213,7 +1215,7 @@ bool hasSuffix(const std::string& str, const std::string& suffix) {
   return str.compare(str.length() - suffix.length(), suffix.length(), suffix) == 0;
 }
 
-void Freenect2ReplayDevice::run() {
+bool Freenect2ReplayDevice::run() {
   DIR *d;
   struct dirent *dir;
 
@@ -1258,6 +1260,8 @@ void Freenect2ReplayDevice::run() {
       delete[] packet.buffer;
     }
   }
+  
+  return true;
 }
 
 } /* namespace libfreenect2 */

--- a/src/libfreenect2.cpp
+++ b/src/libfreenect2.cpp
@@ -1121,7 +1121,52 @@ Freenect2Device *Freenect2::openDefaultDevice(const PacketPipeline *pipeline)
 
 
 Freenect2ReplayDevice::Freenect2ReplayDevice(char* directory, PacketPipeline* pipeline) 
-  :pipeline_(pipeline), directory_(directory), running_(false) {
+  :pipeline_(pipeline), directory_(directory), running_(false)
+{
+}
+
+std::string Freenect2ReplayDevice::getSerialNumber()
+{
+  // Reasonable assumption given it is a software serial, unless
+  // want to include a DOI, or OS/build, or some arbitrary
+  // SHA1 commit
+  return LIBFREENECT2_VERSION;
+}
+
+std::string Freenect2ReplayDevice::getFirmwareVersion()
+{
+  // Resonable assumption as well
+  char apiVer[3] = {0};
+  std::string replayFirmware = LIBFREENECT2_VERSION;
+  sprintf(apiVer, "%d", LIBFREENECT2_API_VERSION);
+  return replayFirmware + apiVer;
+}
+
+Freenect2Device::ColorCameraParams Freenect2ReplayDevice::getColorCameraParams()
+{
+  return rgb_camera_params_;
+}
+
+Freenect2Device::IrCameraParams Freenect2ReplayDevice::getIrCameraParams()
+{
+  return ir_camera_params_;
+}
+
+void Freenect2ReplayDevice::setColorCameraParams(const Freenect2Device::ColorCameraParams &params)
+{
+  rgb_camera_params_ = params;
+}
+
+void Freenect2ReplayDevice::setIrCameraParams(const Freenect2Device::IrCameraParams &params)
+{
+  ir_camera_params_ = params;
+  DepthPacketProcessor *proc = pipeline_->getDepthPacketProcessor();
+  if (proc != 0)
+  {
+    IrCameraTables tables(params);
+    proc->loadXZTables(&tables.xtable[0], &tables.ztable[0]);
+    proc->loadLookupTable(&tables.lut[0]);
+  }
 }
 
 void Freenect2ReplayDevice::setColorFrameListener(FrameListener* listener) {

--- a/src/libfreenect2.cpp
+++ b/src/libfreenect2.cpp
@@ -1169,25 +1169,39 @@ void Freenect2ReplayDevice::setIrCameraParams(const Freenect2Device::IrCameraPar
   }
 }
 
-void Freenect2ReplayDevice::setColorFrameListener(FrameListener* listener) {
+void Freenect2ReplayDevice::setConfiguration(const Freenect2Device::Config &config)
+{
+  DepthPacketProcessor *proc = pipeline_->getDepthPacketProcessor();
+  if (proc != 0)
+    proc->setConfiguration(config);
+}
+
+void Freenect2ReplayDevice::setColorFrameListener(FrameListener* listener)
+{
   RgbPacketProcessor* proc = pipeline_->getRgbPacketProcessor();
-  if (proc != NULL) {
+  if (proc != NULL)
+  {
     proc->setFrameListener(listener);
   }
 }
 
-void Freenect2ReplayDevice::setIrAndDepthFrameListener(FrameListener* listener) {
+void Freenect2ReplayDevice::setIrAndDepthFrameListener(FrameListener* listener)
+{
   DepthPacketProcessor* proc = pipeline_->getDepthPacketProcessor();
-  if (proc != NULL) {
+  if (proc != NULL)
+  {
     proc->setFrameListener(listener);
   }
 }
 
-bool Freenect2ReplayDevice::processRawFrame(Frame::Type type, Frame* frame) {
-  if (frame->format != Frame::Raw) {
+bool Freenect2ReplayDevice::processRawFrame(Frame::Type type, Frame* frame)
+{
+  if (frame->format != Frame::Raw)
+  {
     return false;
   }
-  switch (type) {
+  switch (type)
+  {
   case Frame::Color:
     processRgbFrame(frame);
     break;
@@ -1200,7 +1214,8 @@ bool Freenect2ReplayDevice::processRawFrame(Frame::Type type, Frame* frame) {
   return true;
 }
 
-void Freenect2ReplayDevice::processRgbFrame(Frame* frame) {
+void Freenect2ReplayDevice::processRgbFrame(Frame* frame)
+{
   RgbPacket packet;
   packet.timestamp = frame->timestamp;
   packet.sequence = frame->sequence;
@@ -1213,7 +1228,8 @@ void Freenect2ReplayDevice::processRgbFrame(Frame* frame) {
   pipeline_->getRgbPacketProcessor()->process(packet);
 }
 
-void Freenect2ReplayDevice::processDepthFrame(Frame* frame) {
+void Freenect2ReplayDevice::processDepthFrame(Frame* frame)
+{
   DepthPacket packet;
   packet.timestamp = frame->timestamp;
   packet.sequence = frame->sequence;
@@ -1223,29 +1239,54 @@ void Freenect2ReplayDevice::processDepthFrame(Frame* frame) {
   pipeline_->getDepthPacketProcessor()->process(packet);
 }
 
-void Freenect2ReplayDevice::loadP0Tables(unsigned char* buffer, size_t buffer_length) {
+void Freenect2ReplayDevice::loadP0Tables(unsigned char* buffer, size_t buffer_length)
+{
   pipeline_->getDepthPacketProcessor()->loadP0TablesFromCommandResponse(buffer, buffer_length);
 }
 
-void Freenect2ReplayDevice::loadXZTables(const float *xtable, const float *ztable) {
+void Freenect2ReplayDevice::loadXZTables(const float *xtable, const float *ztable)
+{
   pipeline_->getDepthPacketProcessor()->loadXZTables(xtable, ztable);
 }
 
-void Freenect2ReplayDevice::loadLookupTable(const short *lut) {
+void Freenect2ReplayDevice::loadLookupTable(const short *lut)
+{
   pipeline_->getDepthPacketProcessor()->loadLookupTable(lut);
 }
 
-void runner (void* arg) {
+void runner (void* arg)
+{
   static_cast<Freenect2ReplayDevice*>(arg)->run();
 }
 
-bool Freenect2ReplayDevice::start() {
+bool Freenect2ReplayDevice::start()
+{
   running_ = true;
+  startStreams(true, true);
   t_ = new thread(runner, this);
   return running_;
 }
 
-bool Freenect2ReplayDevice::stop() {
+bool Freenect2ReplayDevice::startStreams(bool enable_rgb, bool enable_depth)
+{
+  LOG_INFO << "starting...: rgb: " << enable_rgb << ", depth: " << enable_depth;
+
+  if (enable_rgb)
+  {
+    LOG_INFO << "starting rgb replay...";
+  }
+
+  if (enable_depth)
+  {
+    LOG_INFO << "submitting depth replay...";
+  }
+
+  LOG_INFO << "started";
+  return true;
+}
+
+bool Freenect2ReplayDevice::stop()
+{
   running_ = false;
   t_->join();
   delete t_;
@@ -1253,21 +1294,25 @@ bool Freenect2ReplayDevice::stop() {
   return !running_;
 }
 
-bool hasSuffix(const std::string& str, const std::string& suffix) {
-  if (str.length() < suffix.length()) {
+bool hasSuffix(const std::string& str, const std::string& suffix)
+{
+  if (str.length() < suffix.length())
+  {
     return false;
   }
   return str.compare(str.length() - suffix.length(), suffix.length(), suffix) == 0;
 }
 
-bool Freenect2ReplayDevice::run() {
+bool Freenect2ReplayDevice::run()
+{
   DIR *d;
   struct dirent *dir;
 
   std::vector<std::string> frames;
 
   d = opendir(directory_);
-  while ((dir = readdir(d)) != NULL) {
+  while ((dir = readdir(d)) != NULL)
+  {
     std::string name = dir->d_name;
     if (hasSuffix(name, ".depth")) {
       frames.push_back(name);


### PR DESCRIPTION
This PR addresses most of the issues of PR #555. However, I chose to split the work of portable `dirent`/`opendir` and RGB processing into separate PRs and in coordination with #602. Please review and comment, should cleanly apply to the current master. This is based off @brendandburns's original implementation. Supersedes #555.