### PR TITLE
remove commands for building libusb usbdk dlls

### DIFF
--- a/depends/install_libusb_vs2013.cmd
+++ b/depends/install_libusb_vs2013.cmd
@@ -11,7 +11,6 @@ set YEAR=2013
 set MSBUILD="C:\Program Files (x86)\MSBuild\12.0\Bin\MSBuild.exe"
 
 %MSBUILD% msvc\libusb_dll_%YEAR%.vcxproj /p:Platform=x64 /p:Configuration=%CONFIG% /target:Rebuild || exit /b
-%MSBUILD% msvc\libusb_usbdk_dll_%YEAR%.vcxproj /p:Platform=x64 /p:Configuration=%CONFIG% /target:Rebuild || exit /b
 
 mkdir ..\libusb\include\libusb-1.0
 copy libusb\libusb.h ..\libusb\include\libusb-1.0

--- a/depends/install_libusb_vs2015.cmd
+++ b/depends/install_libusb_vs2015.cmd
@@ -11,7 +11,6 @@ set YEAR=2015
 set MSBUILD="C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe"
 
 %MSBUILD% msvc\libusb_dll_%YEAR%.vcxproj /p:Platform=x64 /p:Configuration=%CONFIG% /target:Rebuild || exit /b
-%MSBUILD% msvc\libusb_usbdk_dll_%YEAR%.vcxproj /p:Platform=x64 /p:Configuration=%CONFIG% /target:Rebuild || exit /b
 
 mkdir ..\libusb\include\libusb-1.0
 copy libusb\libusb.h ..\libusb\include\libusb-1.0


### PR DESCRIPTION
libusb has removed libusb_usbdk_dll project files in https://github.com/libusb/libusb/commit/020103af78c55a9e0d01fbabecbd4d2108801c4a