### PR TITLE
add libusb_set_option for using usbdk on windows

### DIFF
--- a/src/libfreenect2.cpp
+++ b/src/libfreenect2.cpp
@@ -370,6 +370,15 @@ public:
         LOG_ERROR << "failed to create usb context: " << WRITE_LIBUSB_ERROR(r);
         return;
       }
+
+#ifdef _WIN32
+      r = libusb_set_option((libusb_context*)usb_context, LIBUSB_OPTION_USE_USBDK);
+      if (r != LIBUSB_SUCCESS)
+      {
+          LOG_ERROR << "failed setting UsbDK mode: " << WRITE_LIBUSB_ERROR(r);
+          return;
+      }
+#endif
     }
 
     usb_event_loop_.start(usb_context_);

--- a/src/libfreenect2.cpp
+++ b/src/libfreenect2.cpp
@@ -372,7 +372,7 @@ public:
       }
 
 #if defined(_WIN32) || defined (__WIN32__) || defined(__WINDOWS__)
-      (void)libusb_set_option((libusb_context*)usb_context, LIBUSB_OPTION_USE_USBDK);
+      (void)libusb_set_option(usb_context_, LIBUSB_OPTION_USE_USBDK);
 #endif
     }
 

--- a/src/libfreenect2.cpp
+++ b/src/libfreenect2.cpp
@@ -371,13 +371,8 @@ public:
         return;
       }
 
-#ifdef _WIN32
-      r = libusb_set_option((libusb_context*)usb_context, LIBUSB_OPTION_USE_USBDK);
-      if (r != LIBUSB_SUCCESS)
-      {
-          LOG_ERROR << "failed setting UsbDK mode: " << WRITE_LIBUSB_ERROR(r);
-          return;
-      }
+#if defined(_WIN32) || defined (__WIN32__) || defined(__WINDOWS__)
+      (void)libusb_set_option((libusb_context*)usb_context, LIBUSB_OPTION_USE_USBDK);
 #endif
     }
 


### PR DESCRIPTION
(This message also describes a potential bug in libusb, to be submitted in their bugtracker once this is verified here)

This commit adds a required (?) call to `libusb_set_option()` with latest version of libusb, which includes UsbDK backend ever since https://github.com/libusb/libusb/commit/54884e84d024e761450287ab56aca8fc69f45d01

Currently this commit does not work: From what I understand there's a bug in libusb with this function. libusb requires backends to define the [assorted functions](https://github.com/libusb/libusb/blob/master/libusb/libusbi.h#L598), which is done [here](https://github.com/libusb/libusb/blob/master/libusb/os/windows_nt_common.c#L982). However, once `libusb_set_option()` is called to set the UsbDK mode, the functions are changed, and the backend is [assigned](https://github.com/libusb/libusb/blob/master/libusb/os/windows_nt_common.c#L726) to a different set of [function pointers](https://github.com/libusb/libusb/blob/master/libusb/os/windows_usbdk.c#L797)

Once [get_max_iso_packet_size is called](https://github.com/OpenKinect/libfreenect2/blob/master/src/usb_control.cpp#L138), a NULL function pointer is called and a crash happens [here](https://github.com/libusb/libusb/blob/master/libusb/os/windows_nt_common.c#L785).

Without using `libusb_set_option()` I don't currently get any Kinects detected using Protonect.