### PR TITLE
fix OSX RPATH handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ ENDIF()
 
 PROJECT(libfreenect2)
 
+IF(POLICY CMP0042)
+  cmake_policy(SET CMP0042 NEW)
+ENDIF()
+
 SET(MY_DIR ${libfreenect2_SOURCE_DIR})
 SET(DEPENDS_DIR "${MY_DIR}/depends" CACHE STRING "dependency directory must be set to 'false' if external deps are used")
 


### PR DESCRIPTION
The policy is set to ON by default, this checks first for the policy and if it is set (AKA newer-ish versions of CMake) and APPLE, turns it on.

I think this is the right way to set this, but I'm not entirely sure when this cmake variable is introduced / if checking `if(APPLE)` instead is all that is needed.

Edit: it also works if you set the policy to be new, but that's less clear than just fixing it manually.  AKA I'm not sure what the "right" way to fix this is...