### PR TITLE
homebrew/versions formulae were migrated to hombrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ Use your favorite package managers (brew, ports, etc.) to install most if not al
     ```
     brew update
     brew install libusb
-    brew tap homebrew/versions
     brew install glfw3
     ```
 * Install TurboJPEG (optional)


### PR DESCRIPTION
homebrew-core is the default formulae barrel, so no need to tap
see https://github.com/mrirecon/homebrew-bart/issues/1