### PR TITLE
Add setting of LEDs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ SET(SOURCES
   include/libfreenect2/frame_listener_impl.h
   include/libfreenect2/libfreenect2.hpp
   include/libfreenect2/color_settings.h
+  include/libfreenect2/led_settings.h
   include/libfreenect2/packet_pipeline.h
   include/internal/libfreenect2/packet_processor.h
   include/libfreenect2/registration.h

--- a/include/internal/libfreenect2/protocol/command.h
+++ b/include/internal/libfreenect2/protocol/command.h
@@ -30,6 +30,7 @@
 #include <stdint.h>
 #include <cstring>
 #include "libfreenect2/protocol/response.h"
+#include "libfreenect2/led_settings.h"
 
 #define KCMD_READ_FIRMWARE_VERSIONS 0x02
 #define KCMD_INIT_STREAMS 0x09
@@ -42,6 +43,7 @@
 #define KCMD_SET_MODE 0x4B
 
 #define KCMD_RGB_SETTING 0x3E  // Command value for color camera settings
+#define KCMD_LED_SETTING  0x4B
 
 #define KCMD_0x46 0x46
 #define KCMD_0x47 0x47
@@ -254,6 +256,18 @@ private:
     return out;
   }
 };
+
+
+#define LedSettingResponseSize  0
+struct LedSettingCommand : public libfreenect2::protocol::Command<KCMD_LED_SETTING, LedSettingResponseSize, LedSettingResponseSize, 4>
+{
+  LedSettingCommand(LedSettings led)
+    : Command<KCMD_LED_SETTING, LedSettingResponseSize, LedSettingResponseSize, 4>(0)  // seq always zero
+  {
+    memcpy(this->data_.parameters, &led, sizeof(led));
+  }
+};
+
 
 } /* namespace protocol */
 } /* namespace libfreenect2 */

--- a/include/libfreenect2/led_settings.h
+++ b/include/libfreenect2/led_settings.h
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the OpenKinect Project. http://www.openkinect.org
+ *
+ * Copyright (c) 2011 individual OpenKinect contributors. See the CONTRIB file
+ * for details.
+ *
+ * This code is licensed to you under the terms of the Apache License, version
+ * 2.0, or, at your option, the terms of the GNU General Public License,
+ * version 2.0. See the APACHE20 and GPL2 files for the text of the licenses,
+ * or the following URLs:
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * If you redistribute this file in source form, modified or unmodified, you
+ * may:
+ *   1) Leave this header intact and distribute it under the same terms,
+ *      accompanying it with the APACHE20 and GPL20 files, or
+ *   2) Delete the Apache 2.0 clause and accompany it with the GPL2 file, or
+ *   3) Delete the GPL v2 clause and accompany it with the APACHE20 file
+ * In all cases you must keep the copyright notice intact and include a copy
+ * of the CONTRIB file.
+ *
+ * Binary distributions must follow the binary distribution requirements of
+ * either License.
+ */
+
+#ifndef LED_SETTINGS_H_
+#define LED_SETTINGS_H_
+
+namespace libfreenect2
+{
+
+// The following information was found by using the library released by Microsoft under MIT license,
+// https://github.com/Microsoft/MixedRealityCompanionKit/tree/master/KinectIPD/NuiSensor
+// Debugging the library assembly shows the original struct name was _PETRA_LED_STATE.
+struct LedSettings
+{
+  uint16_t LedId;         // LED index  [0, 1]
+  uint16_t Mode;          // 0 = constant, 1 = blink between StartLevel, StopLevel every IntervalInMs ms
+  uint16_t StartLevel;    // LED intensity  [0, 1000]
+  uint16_t StopLevel;     // LED intensity  [0, 1000]
+  uint32_t IntervalInMs;  // Blink interval for Mode=1 in milliseconds
+  uint32_t Reserved;      // 0
+};
+
+} /* namespace libfreenect2 */
+
+#endif /* LED_SETTINGS_H_ */

--- a/include/libfreenect2/libfreenect2.hpp
+++ b/include/libfreenect2/libfreenect2.hpp
@@ -33,6 +33,7 @@
 #include <libfreenect2/frame_listener.hpp>
 #include <libfreenect2/packet_pipeline.h>
 #include <libfreenect2/color_settings.h>
+#include <libfreenect2/led_settings.h>
 #include <string>
 #include <vector>
 
@@ -199,6 +200,11 @@ public:
   virtual void setColorSetting(ColorSettingCommandType cmd, float value) = 0;
   virtual uint32_t getColorSetting(ColorSettingCommandType cmd) = 0;
   virtual float getColorSettingFloat(ColorSettingCommandType cmd) = 0;
+
+  /** Set the settings of a Kinect LED.
+   * @param led Settings for a single LED.
+   */
+  virtual void setLedStatus(LedSettings led) = 0;
 
   /** Start data processing with both RGB and depth streams.
    * All above configuration must only be called before start() or after stop().

--- a/src/libfreenect2.cpp
+++ b/src/libfreenect2.cpp
@@ -263,6 +263,7 @@ public:
   virtual void setColorSetting(ColorSettingCommandType cmd, float value);
   virtual uint32_t getColorSetting(ColorSettingCommandType cmd);
   virtual float getColorSettingFloat(ColorSettingCommandType cmd);
+  virtual void setLedStatus(LedSettings led);
   virtual bool start();
   virtual bool startStreams(bool rgb, bool depth);
   virtual bool stop();
@@ -294,6 +295,7 @@ public:
   virtual void setColorSetting(ColorSettingCommandType cmd, float value) {}
   virtual uint32_t getColorSetting(ColorSettingCommandType cmd) { return 0u; }
   virtual float getColorSettingFloat(ColorSettingCommandType cmd) { return 0.0f; }
+  virtual void setLedStatus(LedSettings led) {}
 
   bool open();
 
@@ -808,6 +810,12 @@ float Freenect2DeviceImpl::getColorSettingFloat(ColorSettingCommandType cmd)
   float out;
   memcpy(&out, &data, sizeof(out));
   return out;
+}
+
+void Freenect2DeviceImpl::setLedStatus(LedSettings led)
+{
+  CommandTransaction::Result result;
+  command_tx_.execute(LedSettingCommand(led), result);
 }
 
 bool Freenect2DeviceImpl::open()


### PR DESCRIPTION
This allows setting of LEDs on the Kinect2 sensor. The LEDs can be set independently to various brightness levels [0, 1000], and also to blink between two brightness levels at some frequency (by giving a half-period value in milliseconds). The two LEDs can have different settings.

This is another product of my debugging though Microsoft's [NuiSensorLib](https://github.com/Microsoft/MixedRealityCompanionKit/tree/master/KinectIPD/NuiSensor). The NuiSensorLib library only ever sets the LEDs to a constant brightness, either on or off, but debugging shows the underlying structure with extra fields for LED mode (on or blink) and blink mode plus time between toggle.
