### PR TITLE
Add build script for Android

### DIFF
--- a/platform/android/README.md
+++ b/platform/android/README.md
@@ -1,0 +1,42 @@
+# Build libfreenect2 for Android
+
+## 1. Requirements
+
+* A latest release of Android NDK.
+* A rooted Android device with USB3.0 host.
+
+## 2. Build libusb
+
+* See the [official documentation](https://github.com/libusb/libusb/blob/master/android/README) for instructions to build libusb for Android.
+* Due to [certain modifications](https://github.com/libusb/libusb/commit/2f3bc98b0d0f4766496df53c855685a5f0e5e7cf), libusb can no longer be used directly on Android. Grab a latest available [release](https://github.com/libusb/libusb/releases/tag/v1.0.22) instead.
+* The arm64-v8a build of libusb segfaults, use an armeabi-v7a build instead if you are running Android on arm64.
+
+## 3. Build libturbojpeg
+
+* See the [official documentation](https://github.com/libjpeg-turbo/libjpeg-turbo/blob/master/BUILDING.md) for instructions to build libturbojpeg for Android.
+* May encounter problems when using the master branch of libturbojpeg with libfreenect2. However, [2.0.1 release](https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/2.0.1) and older versions work well.
+
+## 4. Build libfreenect2
+
+* Grab libfreenect2 and change into Android build directory.
+
+```bash
+git clone https://github.com/OpenKinect/libfreenect2.git
+cd libfreenect2/platform/android/jni
+```
+
+* Build libfreenect2 with Android NDK.
+
+```bash
+/path/to/ndk-build \
+  LIBUSB_ROOT=/path/to/libusb/root \
+  LIBUSB_SHARED_REL=relative/path/to/libusb1.0.so \
+  LIBTURBOJPEG_ROOT=/path/to/libturbojpeg \
+  LIBTURBOJPEG_SHARED_REL=relative/path/to/libturbojpeg.so
+```
+
+* You will find the built binaries in platform/android/libs.
+
+## 5. Notes
+
+* Now we can only use CPU for depth packet processing. OpenGL ES on Android should work, but it's not yet supported.

--- a/platform/android/jni/Android.mk
+++ b/platform/android/jni/Android.mk
@@ -1,0 +1,5 @@
+
+LOCAL_PATH := $(call my-dir)
+
+include $(LOCAL_PATH)/libfreenect2.mk
+include $(LOCAL_PATH)/examples.mk

--- a/platform/android/jni/Application.mk
+++ b/platform/android/jni/Application.mk
@@ -1,0 +1,5 @@
+
+APP_ABI := armeabi-v7a
+APP_PLATFORM := android-21
+APP_STL := c++_shared
+APP_CPPFLAGS := -fexceptions -std=c++11

--- a/platform/android/jni/examples.mk
+++ b/platform/android/jni/examples.mk
@@ -1,0 +1,16 @@
+
+include $(CLEAR_VARS)
+
+LIBFREENECT2_ROOT := ../../..
+
+LOCAL_SRC_FILES := $(LIBFREENECT2_ROOT)/examples/Protonect.cpp
+
+LOCAL_C_INCLUDES += \
+  $(LIBFREENECT2_ROOT)/include \
+  $(LIBFREENECT2_ROOT)/platform/android
+
+LOCAL_SHARED_LIBRARIES += libfreenect2
+
+LOCAL_MODULE := Protonect
+
+include $(BUILD_EXECUTABLE)

--- a/platform/android/jni/libfreenect2.mk
+++ b/platform/android/jni/libfreenect2.mk
@@ -1,0 +1,50 @@
+
+LIBFREENECT2_ROOT := ../../..
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libusb
+LOCAL_SRC_FILES := $(LIBUSB_ROOT)/$(LIBUSB_SHARED_REL)
+include $(PREBUILT_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libturbojpeg
+LOCAL_SRC_FILES := $(LIBTURBOJPEG_ROOT)/$(LIBTURBOJPEG_SHARED_REL)
+include $(PREBUILT_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+
+LIBFREENECT2_SRC := $(LIBFREENECT2_ROOT)/src
+
+LOCAL_C_INCLUDES += \
+  $(LIBUSB_ROOT)/libusb \
+  $(LIBTURBOJPEG_ROOT) \
+  $(LIBFREENECT2_ROOT)/include \
+  $(LIBFREENECT2_ROOT)/include/internal \
+  $(LIBFREENECT2_SRC)/tinythread \
+  $(LIBFREENECT2_ROOT)/platform/android
+
+LOCAL_SRC_FILES := \
+  $(LIBFREENECT2_SRC)/tinythread/tinythread.cpp \
+  $(LIBFREENECT2_SRC)/allocator.cpp \
+  $(LIBFREENECT2_SRC)/command_transaction.cpp \
+  $(LIBFREENECT2_SRC)/cpu_depth_packet_processor.cpp \
+  $(LIBFREENECT2_SRC)/depth_packet_processor.cpp \
+  $(LIBFREENECT2_SRC)/depth_packet_stream_parser.cpp \
+  $(LIBFREENECT2_SRC)/event_loop.cpp \
+  $(LIBFREENECT2_SRC)/frame_listener_impl.cpp \
+  $(LIBFREENECT2_SRC)/libfreenect2.cpp \
+  $(LIBFREENECT2_SRC)/logging.cpp \
+  $(LIBFREENECT2_SRC)/packet_pipeline.cpp \
+  $(LIBFREENECT2_SRC)/registration.cpp \
+  $(LIBFREENECT2_SRC)/resource.cpp \
+  $(LIBFREENECT2_SRC)/rgb_packet_processor.cpp \
+  $(LIBFREENECT2_SRC)/rgb_packet_stream_parser.cpp \
+  $(LIBFREENECT2_SRC)/transfer_pool.cpp \
+  $(LIBFREENECT2_SRC)/turbo_jpeg_rgb_packet_processor.cpp \
+  $(LIBFREENECT2_SRC)/usb_control.cpp 
+
+LOCAL_SHARED_LIBRARIES += libusb libturbojpeg
+
+LOCAL_MODULE := libfreenect2
+
+include $(BUILD_SHARED_LIBRARY)

--- a/platform/android/libfreenect2/config.h
+++ b/platform/android/libfreenect2/config.h
@@ -1,0 +1,15 @@
+#ifndef LIBFREENECT2_CONFIG_H
+#define LIBFREENECT2_CONFIG_H
+
+#define LIBFREENECT2_VERSION "0.2.0"
+#define LIBFREENECT2_API_VERSION ((0 << 16) | 2)
+
+#define LIBFREENECT2_PACK( __Declaration__ ) __Declaration__ __attribute__((__packed__))
+
+#define LIBFREENECT2_API __attribute__((visibility("default")))
+
+#define LIBFREENECT2_WITH_TURBOJPEG_SUPPORT
+#define LIBFREENECT2_THREADING_STDLIB
+#define LIBFREENECT2_WITH_CXX11_SUPPORT
+
+#endif // LIBFREENECT2_CONFIG_H


### PR DESCRIPTION
Add a simple NDK build script for Android support.
Tested on my Hikey 970 board running Android P.

Future support:
* Java bindings.
* OpenGL depth packet processor.