### PR TITLE
Tegra MultiMedia API location has changed

### DIFF
--- a/cmake_modules/FindTegraJPEG.cmake
+++ b/cmake_modules/FindTegraJPEG.cmake
@@ -6,7 +6,7 @@
 FIND_PATH(TegraJPEG_INCLUDE_DIRS
   libjpeg-8b/jpeglib.h
   DOC "Found TegraJPEG include directory"
-  PATHS /usr/src/tegra_multimedia_api/include
+  PATHS /usr/src/tegra_multimedia_api/include /usr/src/jetson_multimedia_api/include
   NO_DEFAULT_PATH
 )
 


### PR DESCRIPTION
From /usr/src/tegra_multimedia_api to /usr/src/jetson_multimedia_api in newest JetPack. Add both path in TegraJPEG_INCLUDE_DIRS FIND_PATH to have backward compatibility.

Based on https://devtalk.nvidia.com/default/topic/1071409/jetson-agx-xavier/agx-xavier-set-up-of-multiple-streams-with-fpd-link-iii/