### PR TITLE
Fix color unmatch when TegraJpeg is enabled for both Protonect and OpenNI2 Driver #774

### DIFF
--- a/cmake_modules/FindTegraJPEG.cmake
+++ b/cmake_modules/FindTegraJPEG.cmake
@@ -6,7 +6,7 @@
 FIND_PATH(TegraJPEG_INCLUDE_DIRS
   libjpeg-8b/jpeglib.h
   DOC "Found TegraJPEG include directory"
-  PATHS /usr/src/tegra_multimedia_api/include
+  PATHS /usr/src/tegra_multimedia_api/include /usr/src/jetson_multimedia_api/include
   NO_DEFAULT_PATH
 )
 

--- a/examples/viewer.h
+++ b/examples/viewer.h
@@ -53,7 +53,11 @@ typedef ImageFormat<2, GL_R16UI, GL_RED_INTEGER, GL_UNSIGNED_SHORT> U16C1;
 typedef ImageFormat<4, GL_R32F, GL_RED, GL_FLOAT> F32C1;
 typedef ImageFormat<8, GL_RG32F, GL_RG, GL_FLOAT> F32C2;
 typedef ImageFormat<12, GL_RGB32F, GL_RGB, GL_FLOAT> F32C3;
-typedef ImageFormat<4, GL_RGBA, GL_BGRA, GL_UNSIGNED_BYTE> F8C4;
+#ifdef LIBFREENECT2_WITH_TEGRAJPEG_SUPPORT
+    typedef ImageFormat<4, GL_RGBA, GL_BGRA, GL_UNSIGNED_BYTE> F8C4;
+#else
+    typedef ImageFormat<4, GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE> F8C4;
+#endif
 typedef ImageFormat<16, GL_RGBA32F, GL_RGBA, GL_FLOAT> F32C4;
 
 template<typename FormatT>

--- a/examples/viewer.h
+++ b/examples/viewer.h
@@ -54,9 +54,9 @@ typedef ImageFormat<4, GL_R32F, GL_RED, GL_FLOAT> F32C1;
 typedef ImageFormat<8, GL_RG32F, GL_RG, GL_FLOAT> F32C2;
 typedef ImageFormat<12, GL_RGB32F, GL_RGB, GL_FLOAT> F32C3;
 #ifdef LIBFREENECT2_WITH_TEGRAJPEG_SUPPORT
-    typedef ImageFormat<4, GL_RGBA, GL_BGRA, GL_UNSIGNED_BYTE> F8C4;
-#else
     typedef ImageFormat<4, GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE> F8C4;
+#else
+    typedef ImageFormat<4, GL_RGBA, GL_BGRA, GL_UNSIGNED_BYTE> F8C4;
 #endif
 typedef ImageFormat<16, GL_RGBA32F, GL_RGBA, GL_FLOAT> F32C4;
 


### PR DESCRIPTION
TegraJPEG only support return RGB but libfreenect2 suppose all jpeg result is BGR.  #774 #1082 